### PR TITLE
add Cocoa, CoreVideo and IOKit to OSX framework list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ LDFLAGS += $(shell pkg-config --libs glfw3 glu gl x11 xrandr xi xxf86vm xcursor 
 else ifeq ($(PLATFORM),OSX)
 CFLAGS += -DPLATFORM_OSX -stdlib=libc++ $(shell pkg-config --cflags glfw3) -I/usr/local/include/
 INCLUDES += -I//Library/Frameworks/GLUI.framework
-LDFLAGS += -framework OpenGL $(shell pkg-config --libs glfw3) -L/usr/local/lib/
+LDFLAGS += -framework OpenGL -framework Cocoa -framework CoreVideo -framework IOKit $(shell pkg-config --libs glfw3) -L/usr/local/lib/
 ARCH = -arch x86_64
 endif
 


### PR DESCRIPTION
Hey Patricio! I needed to add a few frameworks to the Makefile to get this to compile on OSX. The error I got is below

🍻

```
adm:glslViewer adam$ make
src/main.o
g++ -Wall -g -std=c++0x -fpermissive -DPLATFORM_OSX -stdlib=libc++ -I/usr/local/Cellar/glfw3/3.1.1/include  -I/usr/local/include/ -Isrc/ -I//Library/Frameworks/GLUI.framework -g -c src/main.cpp -o src/main.o -Wno-deprecated-declarations
src/shader.o
g++ -Wall -g -std=c++0x -fpermissive -DPLATFORM_OSX -stdlib=libc++ -I/usr/local/Cellar/glfw3/3.1.1/include  -I/usr/local/include/ -Isrc/ -I//Library/Frameworks/GLUI.framework -g -c src/shader.cpp -o src/shader.o -Wno-deprecated-declarations
src/texture.o
g++ -Wall -g -std=c++0x -fpermissive -DPLATFORM_OSX -stdlib=libc++ -I/usr/local/Cellar/glfw3/3.1.1/include  -I/usr/local/include/ -Isrc/ -I//Library/Frameworks/GLUI.framework -g -c src/texture.cpp -o src/texture.o -Wno-deprecated-declarations
src/vboMesh.o
g++ -Wall -g -std=c++0x -fpermissive -DPLATFORM_OSX -stdlib=libc++ -I/usr/local/Cellar/glfw3/3.1.1/include  -I/usr/local/include/ -Isrc/ -I//Library/Frameworks/GLUI.framework -g -c src/vboMesh.cpp -o src/vboMesh.o -Wno-deprecated-declarations
src/vertexLayout.o
g++ -Wall -g -std=c++0x -fpermissive -DPLATFORM_OSX -stdlib=libc++ -I/usr/local/Cellar/glfw3/3.1.1/include  -I/usr/local/include/ -Isrc/ -I//Library/Frameworks/GLUI.framework -g -c src/vertexLayout.cpp -o src/vertexLayout.o -Wno-deprecated-declarations
g++ -Wall -g -std=c++0x -fpermissive -DPLATFORM_OSX -stdlib=libc++ -I/usr/local/Cellar/glfw3/3.1.1/include  -I/usr/local/include/ src/main.o src/shader.o src/texture.o src/vboMesh.o src/vertexLayout.o -lfreeimage -framework OpenGL -L/usr/local/Cellar/glfw3/3.1.1/lib -lglfw3  -L/usr/local/lib/ -o glslViewer
Undefined symbols for architecture x86_64:
  "_CFArrayAppendValue", referenced from:
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
  "_CFArrayApplyFunction", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
  "_CFArrayCreateMutable", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_CFArrayGetCount", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
      _removeJoystick in libglfw3.a(iokit_joystick.m.o)
      _pollJoystickEvents in libglfw3.a(iokit_joystick.m.o)
      __glfwPlatformGetJoystickAxes in libglfw3.a(iokit_joystick.m.o)
      __glfwPlatformGetJoystickButtons in libglfw3.a(iokit_joystick.m.o)
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      ...
  "_CFArrayGetTypeID", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
  "_CFArrayGetValueAtIndex", referenced from:
      _removeJoystick in libglfw3.a(iokit_joystick.m.o)
      _pollJoystickEvents in libglfw3.a(iokit_joystick.m.o)
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetVideoModes in libglfw3.a(cocoa_monitor.m.o)
  "_CFArrayRemoveAllValues", referenced from:
      _removeJoystick in libglfw3.a(iokit_joystick.m.o)
  "_CFBundleCopyResourcesDirectoryURL", referenced from:
      __glfwPlatformInit in libglfw3.a(cocoa_init.m.o)
  "_CFBundleGetBundleWithIdentifier", referenced from:
      __glfwInitContextAPI in libglfw3.a(nsgl_context.m.o)
  "_CFBundleGetFunctionPointerForName", referenced from:
      __glfwPlatformGetProcAddress in libglfw3.a(nsgl_context.m.o)
  "_CFBundleGetMainBundle", referenced from:
      __glfwPlatformInit in libglfw3.a(cocoa_init.m.o)
  "_CFDictionaryGetTypeID", referenced from:
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
  "_CFDictionaryGetValue", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CFDictionaryGetValueIfPresent", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CFGetTypeID", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
  "_CFNumberGetValue", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      _getElementsCFArrayHandler in libglfw3.a(iokit_joystick.m.o)
  "_CFRelease", referenced from:
      __glfwPlatformGetProcAddress in libglfw3.a(nsgl_context.m.o)
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      __glfwTerminateJoysticks in libglfw3.a(iokit_joystick.m.o)
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      _modeIsGood in libglfw3.a(cocoa_monitor.m.o)
      _vidmodeFromCGDisplayMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
      ...
  "_CFStringCompare", referenced from:
      _modeIsGood in libglfw3.a(cocoa_monitor.m.o)
      _vidmodeFromCGDisplayMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformInit in libglfw3.a(cocoa_init.m.o)
  "_CFStringCreateWithCString", referenced from:
      __glfwPlatformGetProcAddress in libglfw3.a(nsgl_context.m.o)
  "_CFStringGetCString", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CFStringGetLength", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CFStringGetMaximumSizeForEncoding", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CFURLCopyLastPathComponent", referenced from:
      __glfwPlatformInit in libglfw3.a(cocoa_init.m.o)
  "_CFURLGetFileSystemRepresentation", referenced from:
      __glfwPlatformInit in libglfw3.a(cocoa_init.m.o)
  "_CFUUIDGetConstantUUIDWithBytes", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_CFUUIDGetUUIDBytes", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_CGAcquireDisplayFadeReservation", referenced from:
      _beginFadeReservation in libglfw3.a(cocoa_monitor.m.o)
  "_CGAssociateMouseAndMouseCursorPosition", referenced from:
      __glfwPlatformApplyCursorMode in libglfw3.a(cocoa_window.m.o)
  "_CGDisplayBounds", referenced from:
      __glfwPlatformGetWindowPos in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformSetWindowPos in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformSetCursorPos in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformGetMonitorPos in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayCopyAllDisplayModes", referenced from:
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetVideoModes in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayCopyDisplayMode", referenced from:
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetVideoMode in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayFade", referenced from:
      _beginFadeReservation in libglfw3.a(cocoa_monitor.m.o)
      _endFadeReservation in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayGammaTableCapacity", referenced from:
      __glfwPlatformGetGammaRamp in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayIOServicePort", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayMirrorsDisplay", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayModeCopyPixelEncoding", referenced from:
      _modeIsGood in libglfw3.a(cocoa_monitor.m.o)
      _vidmodeFromCGDisplayMode in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayModeGetHeight", referenced from:
      _vidmodeFromCGDisplayMode in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayModeGetIOFlags", referenced from:
      _modeIsGood in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayModeGetRefreshRate", referenced from:
      _vidmodeFromCGDisplayMode in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayModeGetWidth", referenced from:
      _vidmodeFromCGDisplayMode in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayModeRelease", referenced from:
      __glfwPlatformGetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwRestoreVideoMode in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplayMoveCursorToPoint", referenced from:
      __glfwPlatformSetCursorPos in libglfw3.a(cocoa_window.m.o)
  "_CGDisplayScreenSize", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CGDisplaySetDisplayMode", referenced from:
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwRestoreVideoMode in libglfw3.a(cocoa_monitor.m.o)
  "_CGEventSourceCreate", referenced from:
      __glfwPlatformInit in libglfw3.a(cocoa_init.m.o)
  "_CGEventSourceSetLocalEventsSuppressionInterval", referenced from:
      __glfwPlatformInit in libglfw3.a(cocoa_init.m.o)
  "_CGGetDisplayTransferByTable", referenced from:
      __glfwPlatformGetGammaRamp in libglfw3.a(cocoa_monitor.m.o)
  "_CGGetOnlineDisplayList", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_CGMainDisplayID", referenced from:
      __glfwPlatformGetWindowPos in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformSetWindowPos in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformSetCursorPos in libglfw3.a(cocoa_window.m.o)
  "_CGReleaseDisplayFadeReservation", referenced from:
      _endFadeReservation in libglfw3.a(cocoa_monitor.m.o)
  "_CGSetDisplayTransferByTable", referenced from:
      __glfwPlatformSetGammaRamp in libglfw3.a(cocoa_monitor.m.o)
  "_CGWarpMouseCursorPosition", referenced from:
      __glfwPlatformSetCursorPos in libglfw3.a(cocoa_window.m.o)
  "_CGWindowLevelForKey", referenced from:
      __glfwPlatformCreateWindow in libglfw3.a(cocoa_window.m.o)
  "_CVDisplayLinkCreateWithCGDisplay", referenced from:
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetVideoModes in libglfw3.a(cocoa_monitor.m.o)
  "_CVDisplayLinkGetNominalOutputVideoRefreshPeriod", referenced from:
      _vidmodeFromCGDisplayMode in libglfw3.a(cocoa_monitor.m.o)
  "_CVDisplayLinkRelease", referenced from:
      __glfwSetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetVideoMode in libglfw3.a(cocoa_monitor.m.o)
      __glfwPlatformGetVideoModes in libglfw3.a(cocoa_monitor.m.o)
  "_IOCreatePlugInInterfaceForService", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_IODisplayCreateInfoDictionary", referenced from:
      __glfwPlatformGetMonitors in libglfw3.a(cocoa_monitor.m.o)
  "_IOIteratorNext", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_IOMasterPort", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_IORegistryEntryCreateCFProperties", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_IORegistryEntryCreateCFProperty", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_IOServiceGetMatchingServices", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_IOServiceMatching", referenced from:
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_NSApp", referenced from:
      -[GLFWApplicationDelegate applicationDidFinishLaunching:] in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformPostEmptyEvent in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformCreateWindow in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformShowWindow in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformPollEvents in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformWaitEvents in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformTerminate in libglfw3.a(cocoa_init.m.o)
      ...
  "_NSAppKitVersionNumber", referenced from:
      -[GLFWWindowDelegate windowDidResize:] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView viewDidChangeBackingProperties] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView scrollWheel:] in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformCreateWindow in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformGetFramebufferSize in libglfw3.a(cocoa_window.m.o)
  "_NSCalibratedRGBColorSpace", referenced from:
      __glfwPlatformCreateCursor in libglfw3.a(cocoa_window.m.o)
  "_NSDefaultRunLoopMode", referenced from:
      __glfwPlatformPollEvents in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformWaitEvents in libglfw3.a(cocoa_window.m.o)
  "_NSFilenamesPboardType", referenced from:
      -[GLFWContentView initWithGlfwWindow:] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView performDragOperation:] in libglfw3.a(cocoa_window.m.o)
  "_NSSelectorFromString", referenced from:
      __glfwPlatformCreateWindow in libglfw3.a(cocoa_window.m.o)
  "_NSStringPboardType", referenced from:
      __glfwPlatformSetClipboardString in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformGetClipboardString in libglfw3.a(cocoa_window.m.o)
  "_NSZeroPoint", referenced from:
      +[GLFWContentView initialize] in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSApplication", referenced from:
      _OBJC_CLASS_$_GLFWApplication in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSArray", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSAutoreleasePool", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
      objc-class-ref in libglfw3.a(cocoa_init.m.o)
  "_OBJC_CLASS_$_NSBitmapImageRep", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSBundle", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSCursor", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSDate", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSEvent", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSImage", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSMenu", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSMenuItem", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSObject", referenced from:
      _OBJC_CLASS_$_GLFWWindowDelegate in libglfw3.a(cocoa_window.m.o)
      _OBJC_CLASS_$_GLFWApplicationDelegate in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSOpenGLContext", referenced from:
      objc-class-ref in libglfw3.a(nsgl_context.m.o)
  "_OBJC_CLASS_$_NSOpenGLPixelFormat", referenced from:
      objc-class-ref in libglfw3.a(nsgl_context.m.o)
  "_OBJC_CLASS_$_NSOpenGLView", referenced from:
      _OBJC_CLASS_$_GLFWContentView in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSPasteboard", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSScreen", referenced from:
      objc-class-ref in libglfw3.a(cocoa_monitor.m.o)
  "_OBJC_CLASS_$_NSString", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSTrackingArea", referenced from:
      objc-class-ref in libglfw3.a(cocoa_window.m.o)
  "_OBJC_CLASS_$_NSWindow", referenced from:
      _OBJC_CLASS_$_GLFWWindow in libglfw3.a(cocoa_window.m.o)
  "_OBJC_METACLASS_$_NSApplication", referenced from:
      _OBJC_METACLASS_$_GLFWApplication in libglfw3.a(cocoa_window.m.o)
  "_OBJC_METACLASS_$_NSObject", referenced from:
      _OBJC_METACLASS_$_GLFWWindowDelegate in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWApplicationDelegate in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWContentView in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWWindow in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWApplication in libglfw3.a(cocoa_window.m.o)
  "_OBJC_METACLASS_$_NSOpenGLView", referenced from:
      _OBJC_METACLASS_$_GLFWContentView in libglfw3.a(cocoa_window.m.o)
  "_OBJC_METACLASS_$_NSWindow", referenced from:
      _OBJC_METACLASS_$_GLFWWindow in libglfw3.a(cocoa_window.m.o)
  "___CFConstantStringClassReference", referenced from:
      CFString in libglfw3.a(cocoa_window.m.o)
      CFString in libglfw3.a(cocoa_window.m.o)
      CFString in libglfw3.a(cocoa_window.m.o)
      CFString in libglfw3.a(cocoa_window.m.o)
      CFString in libglfw3.a(cocoa_window.m.o)
      CFString in libglfw3.a(cocoa_window.m.o)
      CFString in libglfw3.a(cocoa_window.m.o)
      ...
  "__objc_empty_cache", referenced from:
      _OBJC_CLASS_$_GLFWWindowDelegate in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWWindowDelegate in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWApplicationDelegate in libglfw3.a(cocoa_window.m.o)
      _OBJC_CLASS_$_GLFWApplicationDelegate in libglfw3.a(cocoa_window.m.o)
      _OBJC_CLASS_$_GLFWContentView in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWContentView in libglfw3.a(cocoa_window.m.o)
      _OBJC_METACLASS_$_GLFWWindow in libglfw3.a(cocoa_window.m.o)
      ...
  "_kCFAllocatorDefault", referenced from:
      __glfwPlatformGetProcAddress in libglfw3.a(nsgl_context.m.o)
      __glfwInitJoysticks in libglfw3.a(iokit_joystick.m.o)
  "_objc_msgSend", referenced from:
      _enterFullscreenMode in libglfw3.a(cocoa_window.m.o)
      -[GLFWApplicationDelegate applicationDidFinishLaunching:] in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformPostEmptyEvent in libglfw3.a(cocoa_window.m.o)
      +[GLFWContentView initialize] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView initWithGlfwWindow:] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView dealloc] in libglfw3.a(cocoa_window.m.o)
      _updateModeCursor in libglfw3.a(cocoa_window.m.o)
      ...
  "_objc_msgSendSuper2", referenced from:
      -[GLFWWindowDelegate initWithGlfwWindow:] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView initWithGlfwWindow:] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView dealloc] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView updateTrackingAreas] in libglfw3.a(cocoa_window.m.o)
      -[GLFWApplication sendEvent:] in libglfw3.a(cocoa_window.m.o)
  "_objc_msgSend_stret", referenced from:
      -[GLFWWindowDelegate windowDidResize:] in libglfw3.a(cocoa_window.m.o)
      _centerCursor in libglfw3.a(cocoa_window.m.o)
      __glfwPlatformGetWindowPos in libglfw3.a(cocoa_window.m.o)
      _enterFullscreenMode in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView mouseMoved:] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView viewDidChangeBackingProperties] in libglfw3.a(cocoa_window.m.o)
      -[GLFWContentView updateTrackingAreas] in libglfw3.a(cocoa_window.m.o)
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [glslViewer] Error 1
```