### PR TITLE
Use Xcode command line tools and avoid crash.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.o
+/glslViewer

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ UNAME := $(shell uname -s)
 MACHINE := $(shell uname -m)
 PLATFORM = RPI
 
-INCLUDES +=	-Isrc/ -Iinclude/ -O3
-CFLAGS += -Wall -g -std=c++0x -fpermissive
+INCLUDES +=	-Isrc/ -Iinclude/
+CFLAGS += -Wall -O3 -std=c++0x -fpermissive
 
 ifeq ($(UNAME), Darwin)
 PLATFORM = OSX
@@ -38,10 +38,11 @@ CFLAGS += -DPLATFORM_LINUX $(shell pkg-config --cflags glfw3 glu gl)
 LDFLAGS += $(shell pkg-config --libs glfw3 glu gl x11 xrandr xi xxf86vm xcursor xinerama xrender xext xdamage) -lpthread 
 
 else ifeq ($(PLATFORM),OSX)
-CFLAGS += -DPLATFORM_OSX -stdlib=libc++ $(shell pkg-config --cflags glfw3)
-INCLUDES += -I//Library/Frameworks/GLUI.framework
-LDFLAGS += -framework OpenGL -framework Cocoa -framework CoreVideo -framework IOKit $(shell pkg-config --libs glfw3) -L/usr/local/lib/
+CXX = /usr/bin/clang++
 ARCH = -arch x86_64
+CFLAGS += $(ARCH) -DPLATFORM_OSX -stdlib=libc++ $(shell pkg-config --cflags glfw3)
+INCLUDES += -I/Library/Frameworks/GLUI.framework
+LDFLAGS += $(ARCH) -framework OpenGL -framework Cocoa -framework CoreVideo -framework IOKit $(shell pkg-config --libs glfw3)
 endif
 
 all: $(EXE)

--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -7,7 +7,9 @@ Shader::Shader():m_program(0),m_fragmentShader(0),m_vertexShader(0){
 }
 
 Shader::~Shader() {
-    glDeleteProgram(m_program);
+	if (m_program != 0) {			// Avoid crash when no command line arguments supplied
+    	glDeleteProgram(m_program);
+    }
 }
 
 std::string getLineNumber(const std::string& _source, unsigned _lineNumber){


### PR DESCRIPTION
When no command line options are specified, the program crashes under OSX with:

(lldb) bt
* thread #1: tid = 0x940a, 0x00007fff8b4986fd libGL.dylib`glDeleteProgram + 13, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x1280)
  * frame #0: 0x00007fff8b4986fd libGL.dylib`glDeleteProgram + 13
    frame #1: 0x0000000100019ad6 glslViewer`Shader::~Shader() [inlined] Shader::~Shader(this=<unavailable>) + 22 at shader.cpp:11
    frame #2: 0x0000000100019ac4 glslViewer`Shader::~Shader(this=<unavailable>) + 4 at shader.cpp:9
    frame #3: 0x00007fff913cf8cd libsystem_c.dylib`__cxa_finalize_ranges + 322
    frame #4: 0x00007fff913cfbd0 libsystem_c.dylib`exit + 55
    frame #5: 0x00007fff855dd5d0 libdyld.dylib`start + 8
    frame #6: 0x00007fff855dd5c9 libdyld.dylib`start + 1

Added guard statement to avoid crash.