### PR TITLE
add default swap interval to prevent wasted CPU cycles

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -310,6 +310,7 @@ void renderThread(int argc, char **argv) {
 }
 
 void setup() {
+    glfwSwapInterval(1);
     glEnable(GL_DEPTH_TEST);
     glFrontFace(GL_CCW);
     


### PR DESCRIPTION
I reported issue #24 a little while ago. I believe the issue was because swap interval was not set. Swap interval of 1 is typical setup. 

http://www.glfw.org/docs/latest/group__context.html#ga6d4e0cdf151b5e579bd67f13202994ed