### PR TITLE
fix window resize crash

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -207,7 +207,6 @@ void initGL (glm::ivec4 &_viewport, bool _headless) {
 
         glfwMakeContextCurrent(window);
         glfwSetWindowSizeCallback(window, [](GLFWwindow* _window, int _w, int _h) {
-            devicePixelRatio = getPixelDensity();
             setWindowSize(_w*devicePixelRatio,_h*devicePixelRatio);
         });
 


### PR DESCRIPTION
Issue #44 describes a crash on Ubuntu 16.04, caused by the assignment
to devicePixelRatio in the glfwSetWindowSizeCallback.

This assignment is supposed to handle the case where a window changes
its pixel density due to being moved to another monitor with a different
pixel density.

But, this code doesn't work. It's doesn't do anything useful, because
the WindowSizeCallback doesn't get called when a window is moved to
another monitor (Patricio discovered this during testing).

So I deleted the bad line of code, and fixed the bug.