### PR TITLE
Print shader statistics on load

### DIFF
--- a/src/gl/shader.h
+++ b/src/gl/shader.h
@@ -29,7 +29,7 @@ public:
     bool    isInUse() const;
 
     const   GLint   getAttribLocation(const std::string& _attribute) const;
-    bool    load(const std::string& _fragmentSrc, const std::string& _vertexSrc);
+    bool    load(const std::string& _fragmentSrc, const std::string& _vertexSrc, bool verbose);
 
     void    setUniform(const std::string& _name, float _x);
     void    setUniform(const std::string& _name, float _x, float _y);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -455,7 +455,7 @@ void setup() {
     #ifdef PLATFORM_RPI
     fragSource = "#define PLATFORM_RPI\n"+fragSource;
     #endif
-    shader.load(fragSource, vertSource);
+    shader.load(fragSource, vertSource, true);
     
     cam.setViewport(getWindowWidth(), getWindowHeight());
     cam.setPosition(glm::vec3(0.0,0.0,-3.));
@@ -484,7 +484,7 @@ void main() {\n\
     vec2 st = gl_FragCoord.xy/u_resolution.xy;\n\
     gl_FragColor = texture2D(u_buffer, st);\n\
 }";
-    buffer_shader.load(buffer_frag, buffer_vert);
+    buffer_shader.load(buffer_frag, buffer_vert, false);
 
     // Turn on Alpha blending
     glEnable(GL_BLEND);
@@ -584,14 +584,14 @@ void onFileChange(int index) {
             fragSource = "#define PLATFORM_RPI\n"+fragSource;
             #endif
             shader.detach(GL_FRAGMENT_SHADER | GL_VERTEX_SHADER);
-            shader.load(fragSource, vertSource);
+            shader.load(fragSource, vertSource, true);
         }
     }
     else if (type == "vertex") {
         vertSource = "";
         if (loadFromPath(path, &vertSource)) {
             shader.detach(GL_FRAGMENT_SHADER | GL_VERTEX_SHADER);
-            shader.load(fragSource,vertSource);
+            shader.load(fragSource,vertSource, true);
         }
     }
     else if (type == "geometry") {

--- a/src/ui/cursor.cpp
+++ b/src/ui/cursor.cpp
@@ -40,7 +40,7 @@ void main(void) {
     gl_FragColor = vec4(1.0);
 } );
 
-	m_shader.load(frag,vert);
+	m_shader.load(frag,vert, false);
 }
 
 void Cursor::draw(){


### PR DESCRIPTION
Each time the user's shader program is loaded, I print a line on stderr:
```
shader load time: 2.71828s size: 108242
```
* `load time` is the elapsed time for compiling the fragment and vertex shaders and linking them into a program.
* `size` is the size of the linked program in bytes.
* There is also code to print the # of instructions in the compiled program, but in my tests this always fails so it isn't printed. Might be a limitation of my nVidia driver.