### PR TITLE
new feature: u_view2d

### DIFF
--- a/examples/mandelbrot.frag
+++ b/examples/mandelbrot.frag
@@ -1,0 +1,59 @@
+// Demo of pan and zoom using left-mouse-button drag and scroll-wheel.
+
+uniform mat3 u_view2d;
+uniform vec2 u_resolution;
+
+// bounding box of initial view: [xmin,ymin,xmax,ymax]
+const vec4 bbox = vec4(-2.0, -1.0, 1.0, 1.0);
+
+// A larger value of maxiter gives finer detail.
+const int maxiter = 100;
+
+void main() {
+    // (scale,offset) is a transformation
+    // that centers the bounding box in the window.
+    vec2 size = bbox.zw - bbox.xy;
+    vec2 scale2 = size / u_resolution.xy;
+    vec2 offset = bbox.xy;
+    float scale;
+    if (scale2.x > scale2.y) {
+        scale = scale2.x;
+        offset.y -= (u_resolution.y*scale - size.y)/2;
+    } else {
+        scale = scale2.y;
+        offset.x -= (u_resolution.x*scale - size.x)/2;
+    }
+
+    // Transform the fragment coordinates into model coordinates.
+    vec2 p = (u_view2d * vec3(gl_FragCoord.xy, 1.0)).xy;
+    p = p*scale + offset;
+
+    vec2 c = p;
+
+    // Set default color to HSV value for black
+    vec3 color = vec3(0.0,0.0,0.0);
+
+    for (int i=0; i<maxiter; i++) {
+        //Perform complex number arithmetic
+        p= vec2(p.x*p.x-p.y*p.y,2.0*p.x*p.y)+c;
+        
+        if (dot(p,p)>4.0){
+            // The point, c, is not part of the set, so smoothly color it.
+            // colorRegulator increases linearly by 1 for every extra step it
+            // takes to break free.
+            // http://iquilezles.org/www/articles/mset_smooth/mset_smooth.htm
+            float colorRegulator = float(i-1)-log(((log(dot(p,p)))/log(2.0)))/log(2.0);
+            // An arbitrary HSV color scheme that looks nice.
+            color = vec3(0.95 + .012*colorRegulator , 1.0, .2+.4*(1.0+sin(.3*colorRegulator)));
+            break;
+        }
+    }
+
+    // Change color from HSV to RGB.
+    // https://gist.github.com/patriciogonzalezvivo/114c1653de9e3da6e1e3
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 m = abs(fract(color.xxx + K.xyz) * 6.0 - K.www);
+    gl_FragColor.rgb = color.z * mix(K.xxx, clamp(m - K.xxx, 0.0, 1.0), color.y);
+
+    gl_FragColor.a=1.0;
+}

--- a/src/app.h
+++ b/src/app.h
@@ -46,3 +46,4 @@ void onMouseMove(float _x, float _y);
 void onMouseClick(float _x, float _y, int _button);
 void onMouseDrag(float _x, float _y, int _button);
 void onViewportResize(int _width, int _height);
+void onScroll(float _yoffset);

--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <iostream>
 
-Shader::Shader():m_program(0),m_fragmentShader(0),m_vertexShader(0), m_backbuffer(0), m_time(false), m_delta(false), m_date(false), m_mouse(false), m_imouse(false) {
+Shader::Shader():m_program(0),m_fragmentShader(0),m_vertexShader(0), m_backbuffer(0), m_time(false), m_delta(false), m_date(false), m_mouse(false), m_imouse(false), m_view2d(false) {
 
 }
 
@@ -71,6 +71,7 @@ bool Shader::load(const std::string& _fragmentSrc, const std::string& _vertexSrc
         if (!m_date)
             m_date = find_id(_fragmentSrc, "u_date");
         m_mouse = find_id(_fragmentSrc, "u_mouse");
+        m_view2d = find_id(_fragmentSrc, "u_view2d");
     }
 
     m_program = glCreateProgram();
@@ -151,6 +152,7 @@ GLuint Shader::compileShader(const std::string& _src, GLenum _type) {
             "    mainImage(gl_FragColor, gl_FragCoord.st);\n"
             "}\n";
         prolog =
+            "#define __GLSLVIEWER__ 1\n"
             "uniform vec2 u_resolution;\n"
             "#define iResolution vec3(u_resolution, 1.0)\n"
             "\n";

--- a/src/gl/shader.h
+++ b/src/gl/shader.h
@@ -24,6 +24,7 @@ public:
     const   bool    needDate() const { return m_date; };
     const   bool    needMouse() const { return m_mouse; };
     const   bool    need_iMouse() const { return m_imouse; };
+    const   bool    needView2d() const { return m_view2d; };
 
     void    use() const;
     bool    isInUse() const;
@@ -66,4 +67,5 @@ private:
     bool    m_date;
     bool    m_mouse;
     bool    m_imouse;
+    bool    m_view2d;
 };


### PR DESCRIPTION
New feature: `uniform mat3 u_view2d` is a transformation matrix used by
a fragment shader that displays a 2 dimensional object, and allows you
to explore that object by panning and zooming.
* Pan is controlled by left-mouse-button drag.
* Zoom is controlled by the mouse's scroll wheel.
* The UI is identical to pan and zoom in the Google Maps web site.
* See examples/mandelbrot.frag for a demonstration.

Zooming won't work on Raspberry Pi until the onScroll callback is implemented.

New feature: Shaders can now use `#ifdef __GLSLVIEWER__` to detect if they
are running in a glslViewer environment. Useful for writing code that is
portable between `shadertoy.com` and `glslViewer`.

Bug fix: The mouse velocity goes crazy high if you move the mouse cursor outside
of the window while dragging. This can be reproduced using the `bunny` example.