### PR TITLE
better reporting of GLSL compile messages

### DIFF
--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -44,17 +44,17 @@ bool find_id(const std::string& program, const char* id) {
     return std::strstr(program.c_str(), id) != 0;
 }
 
-bool Shader::load(const std::string& _fragmentSrc, const std::string& _vertexSrc, bool verbose) {
+bool Shader::load(const std::string* _fragmentPath, const std::string& _fragmentSrc, const std::string* _vertexPath, const std::string& _vertexSrc, bool verbose) {
     std::chrono::time_point<std::chrono::steady_clock> start_time, end_time;
     start_time = std::chrono::steady_clock::now();
 
-    m_vertexShader = compileShader(_vertexSrc, GL_VERTEX_SHADER);
+    m_vertexShader = compileShader(_vertexPath, _vertexSrc, GL_VERTEX_SHADER);
 
     if(!m_vertexShader) {
         return false;
     }
 
-    m_fragmentShader = compileShader(_fragmentSrc, GL_FRAGMENT_SHADER);
+    m_fragmentShader = compileShader(_fragmentPath, _fragmentSrc, GL_FRAGMENT_SHADER);
 
     if(!m_fragmentShader) {
         return false;
@@ -136,28 +136,30 @@ bool Shader::isInUse() const {
     return (getProgram() == (GLuint)currentProgram);
 }
 
-GLuint Shader::compileShader(const std::string& _src, GLenum _type) {
+GLuint Shader::compileShader(const std::string* _path, const std::string& _src, GLenum _type) {
     std::string prolog;
     const char* epilog = "";
 
-    prolog += "#define __GLSLVIEWER__ 1\n";
+    if (_path) {
+        prolog += "#define __GLSLVIEWER__ 1\n";
 
-    #ifdef PLATFORM_OSX
-    prolog += "#define PLATFORM_OSX\n";
-    #endif
+        #ifdef PLATFORM_OSX
+        prolog += "#define PLATFORM_OSX\n";
+        #endif
 
-    #ifdef PLATFORM_LINUX
-    prolog += "#define PLATFORM_LINUX\n";
-    #endif
+        #ifdef PLATFORM_LINUX
+        prolog += "#define PLATFORM_LINUX\n";
+        #endif
 
-    #ifdef PLATFORM_RPI
-    prolog += "#define PLATFORM_RPI\n";
-    #endif
+        #ifdef PLATFORM_RPI
+        prolog += "#define PLATFORM_RPI\n";
+        #endif
+    }
 
     // Test if this is a shadertoy.com image shader. If it is, we need to
     // define some uniforms with different names than the glslViewer standard,
     // and we need to add prolog and epilog code.
-    if (_type == GL_FRAGMENT_SHADER && find_id(_src, "mainImage")) {
+    if (_path && _type == GL_FRAGMENT_SHADER && find_id(_src, "mainImage")) {
         epilog =
             "\n"
             "void main(void) {\n"
@@ -196,7 +198,9 @@ GLuint Shader::compileShader(const std::string& _src, GLenum _type) {
         }
     }
 
-    prolog += "#line 1\n";
+    if (_path) {
+        prolog += "#line 1\n";
+    }
 
     const GLchar* sources[3] = {
         (const GLchar*) prolog.c_str(),
@@ -217,7 +221,9 @@ GLuint Shader::compileShader(const std::string& _src, GLenum _type) {
         std::vector<GLchar> infoLog(infoLength);
         glGetShaderInfoLog(shader, infoLength, NULL, &infoLog[0]);
         std::cerr << (isCompiled ? "Warnings" : "Errors");
-        std::cerr << " while compiling shader:\n" << &infoLog[0];
+        std::cerr << " while compiling ";
+        std::cerr << (_path ? *_path : "shader");
+        std::cerr << ":\n" << &infoLog[0];
     }
 
     if (isCompiled == GL_FALSE) {

--- a/src/gl/shader.h
+++ b/src/gl/shader.h
@@ -30,7 +30,7 @@ public:
     bool    isInUse() const;
 
     const   GLint   getAttribLocation(const std::string& _attribute) const;
-    bool    load(const std::string& _fragmentSrc, const std::string& _vertexSrc, bool verbose);
+    bool    load(const std::string* _fragmentPath, const std::string& _fragmentSrc, const std::string* _vertextPath, const std::string& _vertexSrc, bool verbose);
 
     void    setUniform(const std::string& _name, float _x);
     void    setUniform(const std::string& _name, float _x, float _y);
@@ -54,7 +54,7 @@ public:
 
 private:
 
-    GLuint  compileShader(const std::string& _src, GLenum _type);
+    GLuint  compileShader(const std::string* _path, const std::string& _src, GLenum _type);
     GLint   getUniformLocation(const std::string& _uniformName) const;
     
     GLuint  m_program;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,8 +42,10 @@ std::mutex uniformsMutex;
 Shader shader;
 int iFrag = -1;
 std::string fragSource = "";
+const std::string* fragPath = nullptr;
 int iVert = -1;
 std::string vertSource = "";
+const std::string* vertPath = nullptr;
 
 //  CAMERA
 Camera cam;
@@ -429,8 +431,9 @@ void setup() {
     //  Build shader;
     //
     if (iFrag != -1) {
+        fragPath = &files[iFrag].path;
         fragSource = "";
-        if(!loadFromPath(files[iFrag].path, &fragSource)) {
+        if(!loadFromPath(*fragPath, &fragSource)) {
             return;
         }
     }
@@ -439,14 +442,15 @@ void setup() {
     }
 
     if (iVert != -1) {
+        vertPath = &files[iVert].path;
         vertSource = "";
-        loadFromPath(files[iVert].path, &vertSource);
+        loadFromPath(*vertPath, &vertSource);
     }
     else {
         vertSource = vbo->getVertexLayout()->getDefaultVertShader();
     }    
 
-    shader.load(fragSource, vertSource, true);
+    shader.load(fragPath, fragSource, vertPath, vertSource, true);
     
     cam.setViewport(getWindowWidth(), getWindowHeight());
     cam.setPosition(glm::vec3(0.0,0.0,-3.));
@@ -475,7 +479,7 @@ void main() {\n\
     vec2 st = gl_FragCoord.xy/u_resolution.xy;\n\
     gl_FragColor = texture2D(u_buffer, st);\n\
 }";
-    buffer_shader.load(buffer_frag, buffer_vert, false);
+    buffer_shader.load(nullptr, buffer_frag, nullptr, buffer_vert, false);
 
     // Turn on Alpha blending
     glEnable(GL_BLEND);
@@ -567,14 +571,14 @@ void onFileChange(int index) {
         fragSource = "";
         if (loadFromPath(path, &fragSource)) {
             shader.detach(GL_FRAGMENT_SHADER | GL_VERTEX_SHADER);
-            shader.load(fragSource, vertSource, true);
+            shader.load(fragPath, fragSource, vertPath, vertSource, true);
         }
     }
     else if (type == "vertex") {
         vertSource = "";
         if (loadFromPath(path, &vertSource)) {
             shader.detach(GL_FRAGMENT_SHADER | GL_VERTEX_SHADER);
-            shader.load(fragSource,vertSource, true);
+            shader.load(fragPath, fragSource, vertPath, vertSource, true);
         }
     }
     else if (type == "geometry") {

--- a/src/ui/cursor.cpp
+++ b/src/ui/cursor.cpp
@@ -40,7 +40,7 @@ void main(void) {
     gl_FragColor = vec4(1.0);
 } );
 
-	m_shader.load(frag,vert, false);
+	m_shader.load(nullptr, frag, nullptr, vert, false);
 }
 
 void Cursor::draw(){


### PR DESCRIPTION
If there are warning messages, but no error messages, we now report
the warning messages.

We report the pathname of the GLSL source file that contains the warnings
or errors (in case more than one shader is provided).

Line numbers reported in warning or error messages are now more accurate.
After the automatically generated prolog, a '#line 1' directive
is now inserted.

Fixed warnings in "mandelbrot.frag".