### PR TITLE
Show all GLSL warnings

### DIFF
--- a/examples/mandelbrot.frag
+++ b/examples/mandelbrot.frag
@@ -18,10 +18,10 @@ void main() {
     float scale;
     if (scale2.x > scale2.y) {
         scale = scale2.x;
-        offset.y -= (u_resolution.y*scale - size.y)/2;
+        offset.y -= (u_resolution.y*scale - size.y)/2.0;
     } else {
         scale = scale2.y;
-        offset.x -= (u_resolution.x*scale - size.x)/2;
+        offset.x -= (u_resolution.x*scale - size.x)/2.0;
     }
 
     // Transform the fragment coordinates into model coordinates.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -446,17 +446,6 @@ void setup() {
         vertSource = vbo->getVertexLayout()->getDefaultVertShader();
     }    
 
-    #ifdef PLATFORM_OSX
-    fragSource = "#define PLATFORM_OSX\n"+fragSource;
-    #endif
-
-    #ifdef PLATFORM_LINUX
-    fragSource = "#define PLATFORM_LINUX\n"+fragSource;
-    #endif
-
-    #ifdef PLATFORM_RPI
-    fragSource = "#define PLATFORM_RPI\n"+fragSource;
-    #endif
     shader.load(fragSource, vertSource, true);
     
     cam.setViewport(getWindowWidth(), getWindowHeight());
@@ -577,17 +566,6 @@ void onFileChange(int index) {
     if (type == "fragment") {
         fragSource = "";
         if (loadFromPath(path, &fragSource)) {
-            #ifdef PLATFORM_OSX
-            fragSource = "#define PLATFORM_OSX\n"+fragSource;
-            #endif
-
-            #ifdef PLATFORM_LINUX
-            fragSource = "#define PLATFORM_LINUX\n"+fragSource;
-            #endif
-
-            #ifdef PLATFORM_RPI
-            fragSource = "#define PLATFORM_RPI\n"+fragSource;
-            #endif
             shader.detach(GL_FRAGMENT_SHADER | GL_VERTEX_SHADER);
             shader.load(fragSource, vertSource, true);
         }


### PR DESCRIPTION
This PR contains 3 of the 4 changes from "better reporting of GLSL
compile messages", and will be easier to code review.
 1. If there are warning messages, but no error messages,
    we now report the warning messages.
 2. Line numbers reported in warning or error messages are now more accurate.
    After the automatically generated prolog, a '#line 1' directive
    is now inserted.
 3. Fixed warnings in "mandelbrot.frag".

What's missing is the code that prints the path of the shader file
in the case that there are compile messages for the shader.
Since this is the code that you were concerned about during review of PR #51.