### PR TITLE
put load statistics on a single line

### DIFF
--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -104,19 +104,20 @@ bool Shader::load(const std::string* _fragmentPath, const std::string& _fragment
         glDeleteShader(m_fragmentShader);
 
         if (verbose) {
-            std::cerr << "shader load time: " << load_time.count() << "s" << std::endl;
+            std::cerr << "shader load time: " << load_time.count() << "s";
 #ifdef GL_PROGRAM_BINARY_LENGTH
             GLint proglen = 0;
             glGetProgramiv(m_program, GL_PROGRAM_BINARY_LENGTH, &proglen);
             if (proglen > 0)
-                std::cerr << " size: " << proglen << std::endl ;
+                std::cerr << " size: " << proglen;
 #endif
 #ifdef GL_PROGRAM_INSTRUCTIONS_ARB
             GLint icount = 0;
             glGetProgramivARB(m_program, GL_PROGRAM_INSTRUCTIONS_ARB, &icount);
             if (icount > 0)
-                std::cerr << " #instructions: " << icount << std::endl;
+                std::cerr << " #instructions: " << icount;
 #endif
+            std::cerr << std::endl;
         }
 
         return true;


### PR DESCRIPTION
When the shaders are loaded, we print a line containing the load time,
possible the size and possibly the instruction count for the compiled program.

The line looks like this (on my system):
```
shader load time: 0.000336907s size: 10584
```

A previous change inserted extra newlines,
resulting in this:
```
shader load time: 0.000336907s
 size: 10584
```

In this change, I'm removing the extra newlines.
I don't want my terminal to scroll up by 2 lines each time I load a shader,
I'd rather it just scroll up one line.