### PR TITLE
show informative error when glfwInit fails

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -186,6 +186,9 @@ void initGL (glm::ivec4 &_viewport, bool _headless) {
     #else
         // OSX/LINUX use GLFW
         // ---------------------------------------------
+        glfwSetErrorCallback([](int err, const char* msg)->void {
+            std::cerr << "GLFW error "<<err<<": "<<msg<<"\n";
+        });
         if(!glfwInit()) {
             std::cerr << "ABORT: GLFW init failed" << std::endl;
             exit(-1);

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -187,7 +187,7 @@ void initGL (glm::ivec4 &_viewport, bool _headless) {
         // OSX/LINUX use GLFW
         // ---------------------------------------------
         glfwSetErrorCallback([](int err, const char* msg)->void {
-            std::cerr << "GLFW error "<<err<<": "<<msg<<"\n";
+            std::cerr << "GLFW error 0x"<<std::hex<<err<<std::dec<<": "<<msg<<"\n";
         });
         if(!glfwInit()) {
             std::cerr << "ABORT: GLFW init failed" << std::endl;


### PR DESCRIPTION
Here's an example:
```
GLFW error 65544: X11: The DISPLAY environment variable is missing
ABORT: GLFW init failed
```