### PR TITLE
View3d: A viewer for ray-marched 3D shapes

### DIFF
--- a/examples/menger.frag
+++ b/examples/menger.frag
@@ -1,3 +1,5 @@
+// Use mouse scroll wheel to zoom, left button to rotate, right button to pan.
+
 uniform vec3 u_eye3d;
 uniform vec3 u_centre3d;
 uniform vec3 u_up3d;

--- a/examples/menger.frag
+++ b/examples/menger.frag
@@ -1,0 +1,143 @@
+uniform vec3 u_eye3d;
+uniform vec3 u_centre3d;
+uniform vec3 u_up3d;
+
+// The MIT License
+// Copyright © 2013 Inigo Quilez
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// http://www.iquilezles.org/www/articles/menger/menger.htm
+
+float maxcomp(in vec3 p ) { return max(p.x,max(p.y,p.z));}
+float sdBox( vec3 p, vec3 b )
+{
+  vec3  di = abs(p) - b;
+  float mc = maxcomp(di);
+  return min(mc,length(max(di,0.0)));
+}
+
+// result res:
+//   res.x -- signed distance
+//   res.yzw -- initial 1,0,0; 
+vec4 map( in vec3 p )
+{
+    float d = sdBox(p,vec3(1.0));
+    vec4 res = vec4( d, 1.0, 0.0, 0.0 );
+
+    float s = 1.0;
+    for( int m=0; m<4; m++ )
+    {
+        vec3 a = mod( p*s, 2.0 )-1.0;
+        s *= 3.0;
+        vec3 r = abs(1.0 - 3.0*abs(a));
+        float da = max(r.x,r.y);
+        float db = max(r.y,r.z);
+        float dc = max(r.z,r.x);
+        float c = (min(da,min(db,dc))-1.0)/s;
+
+        if( c>d )
+        {
+          d = c;
+          res = vec4( d, min(res.y,0.2*da*db*dc), (1.0+float(m))/4.0, 0.0 );
+        }
+    }
+
+    return res;
+}
+
+vec4 intersect( in vec3 ro, in vec3 rd )
+{
+    float t = 0.0;
+    vec4 res = vec4(-1.0);
+    vec4 h = vec4(1.0);
+    for( int i=0; i<64; i++ )
+    {
+        if( h.x<0.002 || t>10.0 ) break;
+        h = map(ro + rd*t);
+        res = vec4(t,h.yzw);
+        t += h.x;
+    }
+    if( t>10.0 ) res=vec4(-1.0);
+    return res;
+}
+
+float softshadow( in vec3 ro, in vec3 rd, float mint, float k )
+{
+    float res = 1.0;
+    float t = mint;
+    float h = 1.0;
+    for( int i=0; i<32; i++ )
+    {
+        h = map(ro + rd*t).x;
+        res = min( res, k*h/t );
+        t += clamp( h, 0.005, 0.1 );
+    }
+    return clamp(res,0.0,1.0);
+}
+
+vec3 calcNormal(in vec3 pos)
+{
+    vec3  eps = vec3(.001,0.0,0.0);
+    vec3 nor;
+    nor.x = map(pos+eps.xyy).x - map(pos-eps.xyy).x;
+    nor.y = map(pos+eps.yxy).x - map(pos-eps.yxy).x;
+    nor.z = map(pos+eps.yyx).x - map(pos-eps.yyx).x;
+    return normalize(nor);
+}
+
+// light
+vec3 light = normalize(vec3(1.0,0.9,0.3));
+
+// returns: RGB colour
+vec3 render( in vec3 ro, in vec3 rd )
+{
+    // background color
+    vec3 col = mix( vec3(0.3,0.2,0.1)*0.5, vec3(0.7, 0.9, 1.0), 0.5 + 0.5*rd.y );
+    
+    vec4 tmat = intersect(ro,rd);
+    if( tmat.x>0.0 )
+    {
+        vec3  pos = ro + tmat.x*rd;
+        vec3  nor = calcNormal(pos);
+        
+        float occ = tmat.y;
+        float sha = softshadow( pos, light, 0.01, 64.0 );
+
+        float dif = max(0.1 + 0.9*dot(nor,light),0.0);
+        float sky = 0.5 + 0.5*nor.y;
+        float bac = max(0.4 + 0.6*dot(nor,vec3(-light.x,light.y,-light.z)),0.0);
+
+        vec3 lin  = vec3(0.0);
+        lin += 1.00*dif*vec3(1.10,0.85,0.60)*sha;
+        lin += 0.50*sky*vec3(0.10,0.20,0.40)*occ;
+        lin += 0.10*bac*vec3(1.00,1.00,1.00)*(0.5+0.5*occ);
+        lin += 0.25*occ*vec3(0.15,0.17,0.20);    
+
+        vec3 matcol = vec3(
+            0.5+0.5*cos(0.0+2.0*tmat.z),
+            0.5+0.5*cos(1.0+2.0*tmat.z),
+            0.5+0.5*cos(2.0+2.0*tmat.z) );
+        col = matcol * lin;
+    }
+
+    return pow( col, vec3(0.4545) );
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    vec2 p = -1.0 + 2.0 * fragCoord.xy / iResolution.xy;
+    p.x *= iResolution.x/iResolution.y;
+
+    // camera
+    vec3 ro = vec3(-u_eye3d.x, u_eye3d.y, u_eye3d.z);
+    vec3 centre = vec3(-u_centre3d.x, u_centre3d.y, u_centre3d.z);
+    vec3 up = vec3(-u_up3d.x, u_up3d.y, u_up3d.z);
+    vec3 ww = normalize(centre - ro);
+    vec3 uu = normalize(cross( up, ww ));
+    vec3 vv = normalize(cross(ww,uu));
+    vec3 rd = normalize( p.x*uu + p.y*vv + 2.5*ww );
+
+    vec3 col = render( ro, rd );
+    
+    fragColor = vec4(col,1.0);
+}

--- a/examples/raymarch.frag
+++ b/examples/raymarch.frag
@@ -1,3 +1,5 @@
+// Use mouse scroll wheel to zoom, left button to rotate, right button to pan.
+
 uniform vec3 u_eye3d;
 uniform vec3 u_centre3d;
 uniform vec3 u_up3d;

--- a/examples/raymarch.frag
+++ b/examples/raymarch.frag
@@ -1,0 +1,387 @@
+uniform vec3 u_eye3d;
+uniform vec3 u_centre3d;
+uniform vec3 u_up3d;
+
+// based on https://www.shadertoy.com/view/Xds3zN
+// The MIT License
+// Copyright © 2013 Inigo Quilez
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    
+
+// A list of useful distance function to simple primitives, and an example on how to 
+// do some interesting boolean operations, repetition and displacement.
+//
+// More info here: http://www.iquilezles.org/www/articles/distfunctions/distfunctions.htm
+
+
+#define AA 3   // make this 1 is your machine is too slow
+
+//------------------------------------------------------------------
+
+float sdPlane( vec3 p )
+{
+    return p.y;
+}
+
+float sdSphere( vec3 p, float s )
+{
+    return length(p)-s;
+}
+
+float sdBox( vec3 p, vec3 b )
+{
+    vec3 d = abs(p) - b;
+    return min(max(d.x,max(d.y,d.z)),0.0) + length(max(d,0.0));
+}
+
+float sdEllipsoid( in vec3 p, in vec3 r )
+{
+    return (length( p/r ) - 1.0) * min(min(r.x,r.y),r.z);
+}
+
+float udRoundBox( vec3 p, vec3 b, float r )
+{
+    return length(max(abs(p)-b,0.0))-r;
+}
+
+float sdTorus( vec3 p, vec2 t )
+{
+    return length( vec2(length(p.xz)-t.x,p.y) )-t.y;
+}
+
+float sdHexPrism( vec3 p, vec2 h )
+{
+    vec3 q = abs(p);
+#if 0
+    return max(q.z-h.y,max((q.x*0.866025+q.y*0.5),q.y)-h.x);
+#else
+    float d1 = q.z-h.y;
+    float d2 = max((q.x*0.866025+q.y*0.5),q.y)-h.x;
+    return length(max(vec2(d1,d2),0.0)) + min(max(d1,d2), 0.);
+#endif
+}
+
+float sdCapsule( vec3 p, vec3 a, vec3 b, float r )
+{
+    vec3 pa = p-a, ba = b-a;
+    float h = clamp( dot(pa,ba)/dot(ba,ba), 0.0, 1.0 );
+    return length( pa - ba*h ) - r;
+}
+
+float sdTriPrism( vec3 p, vec2 h )
+{
+    vec3 q = abs(p);
+#if 0
+    return max(q.z-h.y,max(q.x*0.866025+p.y*0.5,-p.y)-h.x*0.5);
+#else
+    float d1 = q.z-h.y;
+    float d2 = max(q.x*0.866025+p.y*0.5,-p.y)-h.x*0.5;
+    return length(max(vec2(d1,d2),0.0)) + min(max(d1,d2), 0.);
+#endif
+}
+
+float sdCylinder( vec3 p, vec2 h )
+{
+  vec2 d = abs(vec2(length(p.xz),p.y)) - h;
+  return min(max(d.x,d.y),0.0) + length(max(d,0.0));
+}
+
+float sdCone( in vec3 p, in vec3 c )
+{
+    vec2 q = vec2( length(p.xz), p.y );
+    float d1 = -q.y-c.z;
+    float d2 = max( dot(q,c.xy), q.y);
+    return length(max(vec2(d1,d2),0.0)) + min(max(d1,d2), 0.);
+}
+
+float sdConeSection( in vec3 p, in float h, in float r1, in float r2 )
+{
+    float d1 = -p.y - h;
+    float q = p.y - h;
+    float si = 0.5*(r1-r2)/h;
+    float d2 = max( sqrt( dot(p.xz,p.xz)*(1.0-si*si)) + q*si - r2, q );
+    return length(max(vec2(d1,d2),0.0)) + min(max(d1,d2), 0.);
+}
+
+float sdPryamid4(vec3 p, vec3 h ) // h = { cos a, sin a, height }
+{
+    // Tetrahedron = Octahedron - Cube
+    float box = sdBox( p - vec3(0,-2.0*h.z,0), vec3(2.0*h.z) );
+ 
+    float d = 0.0;
+    d = max( d, abs( dot(p, vec3( -h.x, h.y, 0 )) ));
+    d = max( d, abs( dot(p, vec3(  h.x, h.y, 0 )) ));
+    d = max( d, abs( dot(p, vec3(  0, h.y, h.x )) ));
+    d = max( d, abs( dot(p, vec3(  0, h.y,-h.x )) ));
+    float octa = d - h.z;
+    return max(-box,octa); // Subtraction
+ }
+
+float length2( vec2 p )
+{
+    return sqrt( p.x*p.x + p.y*p.y );
+}
+
+float length6( vec2 p )
+{
+    p = p*p*p; p = p*p;
+    return pow( p.x + p.y, 1.0/6.0 );
+}
+
+float length8( vec2 p )
+{
+    p = p*p; p = p*p; p = p*p;
+    return pow( p.x + p.y, 1.0/8.0 );
+}
+
+float sdTorus82( vec3 p, vec2 t )
+{
+    vec2 q = vec2(length2(p.xz)-t.x,p.y);
+    return length8(q)-t.y;
+}
+
+float sdTorus88( vec3 p, vec2 t )
+{
+    vec2 q = vec2(length8(p.xz)-t.x,p.y);
+    return length8(q)-t.y;
+}
+
+float sdCylinder6( vec3 p, vec2 h )
+{
+    return max( length6(p.xz)-h.x, abs(p.y)-h.y );
+}
+
+//------------------------------------------------------------------
+
+float opS( float d1, float d2 )
+{
+    return max(-d2,d1);
+}
+
+vec2 opU( vec2 d1, vec2 d2 )
+{
+    return (d1.x<d2.x) ? d1 : d2;
+}
+
+vec3 opRep( vec3 p, vec3 c )
+{
+    return mod(p,c)-0.5*c;
+}
+
+vec3 opTwist( vec3 p )
+{
+    float  c = cos(10.0*p.y+10.0);
+    float  s = sin(10.0*p.y+10.0);
+    mat2   m = mat2(c,-s,s,c);
+    return vec3(m*p.xz,p.y);
+}
+
+//------------------------------------------------------------------
+
+// res.x is signed distance to shape, from pos.
+// res.y is "m", the material. Each shape has a material. Union selects the
+//       material of the closer shape.
+vec2 map( in vec3 pos )
+{
+    vec2 res = opU( vec2( sdPlane(     pos), 1.0 ),
+                    vec2( sdSphere(    pos-vec3( 0.0,0.25, 0.0), 0.25 ), 46.9 ) );
+    res = opU( res, vec2( sdBox(       pos-vec3( 1.0,0.25, 0.0), vec3(0.25) ), 3.0 ) );
+    res = opU( res, vec2( udRoundBox(  pos-vec3( 1.0,0.25, 1.0), vec3(0.15), 0.1 ), 41.0 ) );
+    res = opU( res, vec2( sdTorus(     pos-vec3( 0.0,0.25, 1.0), vec2(0.20,0.05) ), 25.0 ) );
+    res = opU( res, vec2( sdCapsule(   pos,vec3(-1.3,0.10,-0.1), vec3(-0.8,0.50,0.2), 0.1  ), 31.9 ) );
+    res = opU( res, vec2( sdTriPrism(  pos-vec3(-1.0,0.25,-1.0), vec2(0.25,0.05) ),43.5 ) );
+    res = opU( res, vec2( sdCylinder(  pos-vec3( 1.0,0.30,-1.0), vec2(0.1,0.2) ), 8.0 ) );
+    res = opU( res, vec2( sdCone(      pos-vec3( 0.0,0.50,-1.0), vec3(0.8,0.6,0.3) ), 55.0 ) );
+    res = opU( res, vec2( sdTorus82(   pos-vec3( 0.0,0.25, 2.0), vec2(0.20,0.05) ),50.0 ) );
+    res = opU( res, vec2( sdTorus88(   pos-vec3(-1.0,0.25, 2.0), vec2(0.20,0.05) ),43.0 ) );
+    res = opU( res, vec2( sdCylinder6( pos-vec3( 1.0,0.30, 2.0), vec2(0.1,0.2) ), 12.0 ) );
+    res = opU( res, vec2( sdHexPrism(  pos-vec3(-1.0,0.20, 1.0), vec2(0.25,0.05) ),17.0 ) );
+    res = opU( res, vec2( sdPryamid4(  pos-vec3(-1.0,0.15,-2.0), vec3(0.8,0.6,0.25) ),37.0 ) );
+    res = opU( res, vec2( opS( udRoundBox(  pos-vec3(-2.0,0.2, 1.0), vec3(0.15),0.05),
+                               sdSphere(    pos-vec3(-2.0,0.2, 1.0), 0.25)), 13.0 ) );
+    res = opU( res, vec2( opS( sdTorus82(  pos-vec3(-2.0,0.2, 0.0), vec2(0.20,0.1)),
+                               sdCylinder(  opRep( vec3(atan(pos.x+2.0,pos.z)/6.2831, pos.y, 0.02+0.5*length(pos-vec3(-2.0,0.2, 0.0))), vec3(0.05,1.0,0.05)), vec2(0.02,0.6))), 51.0 ) );
+    res = opU( res, vec2( 0.5*sdSphere(    pos-vec3(-2.0,0.25,-1.0), 0.2 ) + 0.03*sin(50.0*pos.x)*sin(50.0*pos.y)*sin(50.0*pos.z), 65.0 ) );
+    res = opU( res, vec2( 0.5*sdTorus( opTwist(pos-vec3(-2.0,0.25, 2.0)),vec2(0.20,0.05)), 46.7 ) );
+    res = opU( res, vec2( sdConeSection( pos-vec3( 0.0,0.35,-2.0), 0.15, 0.2, 0.1 ), 13.67 ) );
+    res = opU( res, vec2( sdEllipsoid( pos-vec3( 1.0,0.35,-2.0), vec3(0.15, 0.2, 0.05) ), 43.17 ) );
+        
+    return res;
+}
+
+// ray marching. ro is ray origin, rd is ray direction (unit vector).
+// result is (t,m), where
+//  * t is the distance that we marched,
+//  * m is the material value of the distance field at the point we ended up at.
+//    -1 means no object was hit.
+vec2 castRay( in vec3 ro, in vec3 rd )
+{
+    float tmin = 1.0;
+    float tmax = 20.0;
+   
+#if 0
+    // bounding volume
+    float tp1 = (0.0-ro.y)/rd.y; if( tp1>0.0 ) tmax = min( tmax, tp1 );
+    float tp2 = (1.6-ro.y)/rd.y; if( tp2>0.0 ) { if( ro.y>1.6 ) tmin = max( tmin, tp2 );
+                                                 else           tmax = min( tmax, tp2 ); }
+#endif
+    
+    float t = tmin;
+    float m = -1.0;
+    for( int i=0; i<64; i++ )
+    {
+        float precis = 0.0005*t;
+        vec2 res = map( ro+rd*t );
+        if( res.x<precis || t>tmax ) break;
+        t += res.x;
+        m = res.y;
+    }
+
+    if( t>tmax ) m=-1.0;
+    return vec2( t, m );
+}
+
+
+float softshadow( in vec3 ro, in vec3 rd, in float mint, in float tmax )
+{
+    float res = 1.0;
+    float t = mint;
+    for( int i=0; i<16; i++ )
+    {
+        float h = map( ro + rd*t ).x;
+        res = min( res, 8.0*h/t );
+        t += clamp( h, 0.02, 0.10 );
+        if( h<0.001 || t>tmax ) break;
+    }
+    return clamp( res, 0.0, 1.0 );
+}
+
+vec3 calcNormal( in vec3 pos )
+{
+    vec2 e = vec2(1.0,-1.0)*0.5773*0.0005;
+    return normalize( e.xyy*map( pos + e.xyy ).x + 
+                      e.yyx*map( pos + e.yyx ).x + 
+                      e.yxy*map( pos + e.yxy ).x + 
+                      e.xxx*map( pos + e.xxx ).x );
+    /*
+    vec3 eps = vec3( 0.0005, 0.0, 0.0 );
+    vec3 nor = vec3(
+        map(pos+eps.xyy).x - map(pos-eps.xyy).x,
+        map(pos+eps.yxy).x - map(pos-eps.yxy).x,
+        map(pos+eps.yyx).x - map(pos-eps.yyx).x );
+    return normalize(nor);
+    */
+}
+
+float calcAO( in vec3 pos, in vec3 nor )
+{
+    float occ = 0.0;
+    float sca = 1.0;
+    for( int i=0; i<5; i++ )
+    {
+        float hr = 0.01 + 0.12*float(i)/4.0;
+        vec3 aopos =  nor * hr + pos;
+        float dd = map( aopos ).x;
+        occ += -(dd-hr)*sca;
+        sca *= 0.95;
+    }
+    return clamp( 1.0 - 3.0*occ, 0.0, 1.0 );    
+}
+
+// in ro: ray origin
+// in rd: ray direction
+// out: rgb colour
+vec3 render( in vec3 ro, in vec3 rd )
+{ 
+    vec3 col = vec3(0.7, 0.9, 1.0) +rd.y*0.8;
+    vec2 res = castRay(ro,rd);
+    float t = res.x;
+    float m = res.y;
+    if( m>-0.5 )
+    {
+        vec3 pos = ro + t*rd;
+        vec3 nor = calcNormal( pos );
+        vec3 ref = reflect( rd, nor );
+        
+        // material        
+        col = 0.45 + 0.35*sin( vec3(0.05,0.08,0.10)*(m-1.0) );
+        if( m<1.5 )
+        {
+            
+            float f = mod( floor(5.0*pos.z) + floor(5.0*pos.x), 2.0);
+            col = 0.3 + 0.1*f*vec3(1.0);
+        }
+
+        // lighting        
+        float occ = calcAO( pos, nor );
+        vec3  lig = normalize( vec3(-0.4, 0.7, -0.6) );
+        float amb = clamp( 0.5+0.5*nor.y, 0.0, 1.0 );
+        float dif = clamp( dot( nor, lig ), 0.0, 1.0 );
+        float bac = clamp( dot( nor, normalize(vec3(-lig.x,0.0,-lig.z))), 0.0, 1.0 )*clamp( 1.0-pos.y,0.0,1.0);
+        float dom = smoothstep( -0.1, 0.1, ref.y );
+        float fre = pow( clamp(1.0+dot(nor,rd),0.0,1.0), 2.0 );
+        float spe = pow(clamp( dot( ref, lig ), 0.0, 1.0 ),16.0);
+        
+        dif *= softshadow( pos, lig, 0.02, 2.5 );
+        dom *= softshadow( pos, ref, 0.02, 2.5 );
+
+        vec3 lin = vec3(0.0);
+        lin += 1.30*dif*vec3(1.00,0.80,0.55);
+        lin += 2.00*spe*vec3(1.00,0.90,0.70)*dif;
+        lin += 0.40*amb*vec3(0.40,0.60,1.00)*occ;
+        lin += 0.50*dom*vec3(0.40,0.60,1.00)*occ;
+        lin += 0.50*bac*vec3(0.25,0.25,0.25)*occ;
+        lin += 0.25*fre*vec3(1.00,1.00,1.00)*occ;
+        col = col*lin;
+
+        col = mix( col, vec3(0.8,0.9,1.0), 1.0-exp( -0.0002*t*t*t ) );
+    }
+
+    return vec3( clamp(col,0.0,1.0) );
+}
+
+mat3 look_at( in vec3 eye, in vec3 centre, in vec3 up )
+{
+    vec3 cw = normalize(centre-eye);
+    vec3 cu = normalize( cross(cw,up) );
+    vec3 cv = normalize( cross(cu,cw) );
+    return mat3( cu, cv, cw );
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    vec3 tot = vec3(0.0);
+#if AA>1
+    for( int m=0; m<AA; m++ )
+    for( int n=0; n<AA; n++ )
+    {
+        // pixel coordinates
+        vec2 o = vec2(float(m),float(n)) / float(AA) - 0.5;
+        vec2 p = (-iResolution.xy + 2.0*(fragCoord+o))/iResolution.y;
+#else    
+        vec2 p = (-iResolution.xy + 2.0*fragCoord)/iResolution.y;
+#endif
+
+        // camera   
+        vec3 ro = u_eye3d;
+        vec3 ta = u_centre3d;
+        // camera-to-world transformation
+        mat3 ca = look_at( ro, ta, u_up3d );
+        // ray direction
+        vec3 rd = ca * normalize( vec3(p.xy,2.0) );
+
+        // render   
+        vec3 col = render( ro, rd );
+
+        // gamma
+        col = pow( col, vec3(0.4545) );
+
+        tot += col;
+#if AA>1
+    }
+    tot /= float(AA*AA);
+#endif
+
+    
+    fragColor = vec4( tot, 1.0 );
+}

--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <iostream>
 
-Shader::Shader():m_program(0),m_fragmentShader(0),m_vertexShader(0), m_backbuffer(0), m_time(false), m_delta(false), m_date(false), m_mouse(false), m_imouse(false), m_view2d(false) {
+Shader::Shader():m_program(0),m_fragmentShader(0),m_vertexShader(0), m_backbuffer(0), m_time(false), m_delta(false), m_date(false), m_mouse(false), m_imouse(false), m_view2d(false), m_view3d(false) {
 
 }
 
@@ -68,6 +68,9 @@ bool Shader::load(const std::string* _fragmentPath, const std::string& _fragment
             m_date = find_id(_fragmentSrc, "u_date");
         m_mouse = find_id(_fragmentSrc, "u_mouse");
         m_view2d = find_id(_fragmentSrc, "u_view2d");
+        m_view3d = (find_id(_fragmentSrc, "u_eye3d")
+            || find_id(_fragmentSrc, "u_centre3d")
+            || find_id(_fragmentSrc, "u_up3d"));
     }
 
     m_program = glCreateProgram();

--- a/src/gl/shader.h
+++ b/src/gl/shader.h
@@ -25,6 +25,7 @@ public:
     const   bool    needMouse() const { return m_mouse; };
     const   bool    need_iMouse() const { return m_imouse; };
     const   bool    needView2d() const { return m_view2d; };
+    const   bool    needView3d() const { return m_view3d; };
 
     void    use() const;
     bool    isInUse() const;
@@ -68,4 +69,5 @@ private:
     bool    m_mouse;
     bool    m_imouse;
     bool    m_view2d;
+    bool    m_view3d;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -645,8 +645,7 @@ void onScroll(float _yoffset) {
     /* zoomfactor 2^(1/4): 4 scroll wheel clicks to double in size. */
     constexpr float zoomfactor = 1.1892;
     if (_yoffset != 0) {
-        float z =
-            (_yoffset > 0 ? _yoffset * zoomfactor : 1/(-_yoffset * zoomfactor));
+        float z = pow(zoomfactor, _yoffset);
 
         // zoom view2d
         glm::vec2 zoom = glm::vec2(z,z);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -671,8 +671,10 @@ void onMouseDrag(float _x, float _y, int _button) {
         // Left-button drag is used to rotate eye3d around centre3d.
         // One complete drag across the screen width equals 360 degrees.
         constexpr double tau = 6.283185307179586;
-        float xangle = (getMouseVelX() / getWindowWidth()) * tau;
+        u_eye3d -= u_centre3d;
+        u_up3d -= u_centre3d;
         // Rotate about vertical axis, defined by the 'up' vector.
+        float xangle = (getMouseVelX() / getWindowWidth()) * tau;
         u_eye3d = glm::rotate(u_eye3d, -xangle, u_up3d);
         // Rotate about horizontal axis, which is perpendicular to
         // the (centre3d,eye3d,up3d) plane.
@@ -680,6 +682,9 @@ void onMouseDrag(float _x, float _y, int _button) {
         glm::vec3 haxis = glm::cross(u_eye3d-u_centre3d, u_up3d);
         u_eye3d = glm::rotate(u_eye3d, -yangle, haxis);
         u_up3d = glm::rotate(u_up3d, -yangle, haxis);
+        //
+        u_eye3d += u_centre3d;
+        u_up3d += u_centre3d;
     } else {
         // Right-button drag is used to zoom geometry.
         float dist = glm::length(cam.getPosition());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,8 +57,12 @@ glm::mat3 u_view2d = glm::mat3(1.);
 // Note: the up3d vector must be orthogonal to (eye3d - centre3d),
 // or rotation doesn't work correctly.
 glm::vec3 u_centre3d = glm::vec3(0.,0.,0.);
-glm::vec3 u_eye3d = glm::vec3(0.0,0.0,6.0);
-glm::vec3 u_up3d = glm::vec3(0.0,1.0,0.0);
+// The following initial value for 'eye3d' is derived by starting with [0,0,6],
+// then rotating 30 degrees around the X and Y axes.
+glm::vec3 u_eye3d = glm::vec3(2.598076,3.0,4.5);
+// The initial value for up3d is derived by starting with [0,1,0], then
+// applying the same rotations as above, so that up3d is orthogonal to eye3d.
+glm::vec3 u_up3d = glm::vec3(-0.25,0.866025,-0.433013);
 
 //  ASSETS
 Vbo* vbo;


### PR DESCRIPTION
Suppose you create a 3D scene in a fragment shader, using Function
Representation and ray-marching instead of polygons, as seen on shadertoy.com.

For this use case, I have created a 3D browser that allows you to pan, zoom,
and rotate the 3D scene, using the mouse.

The fragment shader uses 3 uniform variables:
```
  uniform vec3 u_eye3d;
  uniform vec3 u_centre3d;
  uniform vec3 u_up3d;
```
These are the same quantities that are passed to the `lookAt` function in GLM
and other libraries. See the examples `menger.frag` and `raymarch.frag`.

The user interface uses the scroll wheel for zoom, left-button for rotate,
and right-button for pan.
