### PR TITLE
Fix few coding mistakes that make the project building failed on ArchLinux

### DIFF
--- a/src/gl/shader.h
+++ b/src/gl/shader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "gl.h"
 #include "glm/glm.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv){
     #endif
 
     #ifdef PLATFORM_LINUX
-    defines.push_back("PLATFORM_LINUX)";
+    defines.push_back("PLATFORM_LINUX");
     #endif
 
     #ifdef PLATFORM_RPI


### PR DESCRIPTION
```
src/main.cpp:164:40: error: expected ‘)’ before ‘;’ token
     defines.push_back("PLATFORM_LINUX)";
```