### PR TITLE
Fix few g++ warnings

### DIFF
--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -147,7 +147,7 @@ GLuint Shader::compileShader(const std::string& _src, const std::vector<std::str
     std::string prolog = "";
     const char* epilog = "";
 
-    for (int i = 0; i < _defines.size(); i++) {
+    for (unsigned int i = 0; i < _defines.size(); i++) {
         prolog += "#define " + _defines[i] + "\n"; 
     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -282,7 +282,7 @@ std::string urlResolve(const std::string& path, const std::string& pwd, const st
         return url;
     }
     else {
-        for (int i = 0; i < include_folders.size(); i++) {
+        for (unsigned int i = 0; i < include_folders.size(); i++) {
             std::string new_path = include_folders[i] + "/" + path;
             if (urlExists(new_path)) {
                 return new_path;


### PR DESCRIPTION
```
src/utils.cpp:285:27: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         for (int i = 0; i < include_folders.size(); i++) {
                         ~~^~~~~~~~~~~~~~~~~~~~~~~~
```
```
src/gl/shader.cpp:150:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < _defines.size(); i++) {
                     ~~^~~~~~~~~~~~~~~~~
```