### PR TITLE
debounce when setting the window title

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -323,6 +323,22 @@ bool isGL(){
     #endif
 }
 
+#ifndef PLATFORM_RPI
+void debounceSetWindowTitle(std::string title){
+    static double lastUpdated;
+
+    double now = glfwGetTime();
+
+    if ((now - lastUpdated) < 1.) {
+        return;
+    }
+
+    glfwSetWindowTitle(window, title.c_str());
+
+    lastUpdated = now;
+}
+#endif
+
 void updateGL(){
     // Update time
     // --------------------------------------------------------------------
@@ -415,7 +431,7 @@ void updateGL(){
         }
     #else
         std::string title = appTitle + ":..: FPS:" + toString(fFPS);
-        glfwSetWindowTitle(window, title.c_str());
+        debounceSetWindowTitle(title);
 
         // OSX/LINUX
         glfwPollEvents();


### PR DESCRIPTION
Setting the window title on every frame causes plasmashell to
lock up even after you've closed glslViewer. Plasmashell is the
part of the kde desktop that displays the task bar amoung other
things. This patch makes sure we only set the window title
every second.