### PR TITLE
Add help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Beside for texture uniforms other arguments can be add to `glslViewer`:
 
 * `-vFlip` all textures after will be fliped vertically
 
+* `--help` display the available command line options
+
 ### Inject other files
 
 You can include other GLSL code using a traditional `#include "file.glsl"` macro. Note: included files are not under watch so changes will not take effect until the main file is save.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,7 @@ void screenshot(std::string file);
 
 void onFileChange(int index);
 void onExit();
+void printUsage(char *);
 
 // Main program
 //============================================================================
@@ -122,6 +123,7 @@ int main(int argc, char **argv){
     #endif
 
     bool headless = false;
+    bool displayHelp = false;
     for (int i = 1; i < argc ; i++) {
         std::string argument = std::string(argv[i]);
 
@@ -146,6 +148,9 @@ int main(int argc, char **argv){
         else if (   std::string(argv[i]) == "--headless" ) {
             headless = true;
         }
+        else if (   std::string(argv[i]) == "--help" ) {
+            displayHelp = true;
+        }
         #ifdef PLATFORM_RPI
         else if (   std::string(argv[i]) == "-l" ||
                     std::string(argv[i]) == "--life-coding" ){
@@ -153,6 +158,11 @@ int main(int argc, char **argv){
             windowPosAndSize.z = windowPosAndSize.w = 500;
         }
         #endif
+    }
+
+    if (displayHelp) {
+        printUsage(argv[0]);
+        exit(0);
     }
 
     // Initialize openGL context
@@ -318,7 +328,7 @@ int main(int argc, char **argv){
 
     // If no shader
     if (iFrag == -1 && iVert == -1 && iGeom == -1) {
-        std::cerr << "Usage: " << argv[0] << " shader.frag [shader.vert] [mesh.(obj/.ply)] [texture.(png/jpg)] [-textureNameA texture.(png/jpg)] [-u] [-x x] [-y y] [-w width] [-h height] [-l/--livecoding] [--square] [-s seconds] [-o screenshot.png]\n";
+        printUsage(argv[0]);
         onExit();
         exit(EXIT_FAILURE);
     }
@@ -809,4 +819,8 @@ void onExit() {
     }
     textures.clear();
     delete vbo;
+}
+
+void printUsage(char * executableName) {
+    std::cerr << "Usage: " << executableName << " shader.frag [shader.vert] [mesh.(obj/.ply)] [texture.(png/jpg)] [-textureNameA texture.(png/jpg)] [-u] [-x x] [-y y] [-w width] [-h height] [-l/--livecoding] [--square] [-s seconds] [-o screenshot.png] [--help]\n";
 }


### PR DESCRIPTION
I created a pull request [to add glslViewer to Homebrew](https://github.com/Homebrew/homebrew-core/pull/20190). To have the PR merged, there must be a test that can verify the application has been installed successfully. This test is run on [Jenkins](https://jenkins.brew.sh) which is entirely headless so a standard use of glslViewer won't work. However, even using glslViewer's headless switch results in a failure on Jenkins because glfw still needs to create an offscreen window:

```
       Testing glslviewer
/usr/bin/sandbox-exec -f /tmp/homebrew20171107-45628-v7ac9r.sb /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -W0 -I /usr/local/Homebrew/Library/Homebrew -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/glslviewer.rb --verbose
==> /usr/local/Cellar/glslviewer/1.3/bin/glslViewer /tmp/glslviewer-test-20171107-45629-1g5p9lo/test.frag -s 0 --headless
2017-11-07 18:04:59.093 glslViewer[45637:23679043] *** attempt to register for all distributed notifications thwarted by sandboxing.

Date/Time:     Tue Nov  7 18:04:59 2017
OS Version:    17A362a
Application:   glslViewer

Backtrace:
0   CoreFoundation                      0x00007fff3db19349 __CFGenerateReport + 281
1   CoreFoundation                      0x00007fff3da74ea5 __CFXNotificationRegisterObserver + 1045
2   CoreFoundation                      0x00007fff3d97345e _CFXNotificationRegisterObserver + 14
3   Foundation                          0x00007fff3fa281b4 -[NSDistributedNotificationCenter addObserver:selector:name:object:suspensionBehavior:] + 239
4   Foundation                          0x00007fff3fa3124a -[NSDistributedNotificationCenter addObserver:selector:name:object:] + 29
5   libglfw.3.dylib                     0x000000010fad6567 _glfwPlatformInit + 172
6   libglfw.3.dylib                     0x000000010fad34ef glfwInit + 42
7   glslViewer                          0x000000010fa33412 _Z6initGLRN3glm5tvec4IiLNS_9precisionE0EEEb + 34
8   glslViewer                          0x000000010fa351f6 main + 2726
9   libdyld.dylib                       0x00007fff64f4b145 start + 1
10  ???                                 0x0000000000000005 0x0 + 5
GLFW error 0x10009: NSGL: Failed to find a suitable pixel format
ABORT: GLFW create window failed
Error: glslviewer: failed
```

The minimum test requirement that the Homebrew maintainers require is that the application runs with an exit code of 0. I couldn't find a way to get glslViewer to exit 0 without creating a window (headless or otherwise).

This PR adds a new command line option `--help` that prints the usage message, which was previously output only for invalid inputs. If this flag is set, the application will exit with 0 before initialising OpenGL. Merging this will allow progress on the Homebrew PR.