### PR TITLE
Fixed non-working example (it ignores non-float inputs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,11 +365,11 @@ glslViewer examples/platform.frag
 
 ```bash
 glslViewer examples/temp.frag
-u_temp,30
-u_temp,40
-u_temp,50
-u_temp,60
-u_temp,70
+u_temp,30.0
+u_temp,40.0
+u_temp,50.0
+u_temp,60.0
+u_temp,70.0
 ```
 
 * Create a bash script to change uniform parameters on the fly:

--- a/examples/temp.sh
+++ b/examples/temp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 while true; do
-    awk '{print "u_temp,"$1/1000}' /sys/class/thermal/thermal_zone0/temp
+    awk '{print "u_temp,"$1/1000".0"}' /sys/class/thermal/thermal_zone0/temp
     sleep 1
 done


### PR DESCRIPTION
u_temp is a float, but in both README.md and examples/temp.sh, it
passes integers.  As the integers are ignored, the examples do not
work.