### PR TITLE
fix g++6.3 compiler error: ambiguos overload

### DIFF
--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -2,6 +2,7 @@
 
 #include <sys/stat.h>   // stat
 #include <algorithm>    // std::find
+#include <cmath>        // std::abs
 
 #include "window.h"
 
@@ -1001,7 +1002,7 @@ void Sandbox::onMouseDrag(float _x, float _y, int _button) {
         float vel_x = getMouseVelX();
         float vel_y = getMouseVelY();
 
-        if (abs(vel_x) < 50.0 && abs(vel_y) < 50.0) {
+        if (std::abs(vel_x) < 50.0 && std::abs(vel_y) < 50.0) {
             m_lat -= vel_x;
             m_lon -= vel_y * 0.5;
             m_cam.orbit(m_lat, m_lon, dist);


### PR DESCRIPTION
fixes compiler error on raspbian stretch (g++6.3)
great project btw!

```
~/glslViewer $ LANG=en make src/sandbox.o
Platform Raspbian GNU/Linux 9 (stretch)
src/sandbox.o
g++ -Wall -O3 -std=c++11 -fpermissive -DGLM_FORCE_CXX98 -DPLATFORM_RPI -Isrc/ -Iinclude/ -I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -g -c src/sandbox.cpp -o src/sandbox.o -Wno-deprecated-declarations
src/sandbox.cpp: In member function 'void Sandbox::onMouseDrag(float, float, int)':
src/sandbox.cpp:1004:22: error: call of overloaded 'abs(float&)' is ambiguous
         if (abs(vel_x) < 50.0 && abs(vel_y) < 50.0) {
                      ^
In file included from /usr/include/c++/6/cstdlib:75:0,
                 from /usr/include/c++/6/ext/string_conversions.h:41,
                 from /usr/include/c++/6/bits/basic_string.h:5417,
                 from /usr/include/c++/6/string:52,
                 from src/gl/shader.h:3,
                 from src/sandbox.h:3,
                 from src/sandbox.cpp:1:
/usr/include/stdlib.h:735:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
            ^~~
In file included from /usr/include/c++/6/ext/string_conversions.h:41:0,
                 from /usr/include/c++/6/bits/basic_string.h:5417,
                 from /usr/include/c++/6/string:52,
                 from src/gl/shader.h:3,
                 from src/sandbox.h:3,
                 from src/sandbox.cpp:1:
/usr/include/c++/6/cstdlib:180:3: note: candidate: long long int std::abs(long long int)
   abs(long long __x) { return __builtin_llabs (__x); }
   ^~~
/usr/include/c++/6/cstdlib:172:3: note: candidate: long int std::abs(long int)
   abs(long __i) { return __builtin_labs(__i); }
   ^~~
src/sandbox.cpp:1004:43: error: call of overloaded 'abs(float&)' is ambiguous
         if (abs(vel_x) < 50.0 && abs(vel_y) < 50.0) {
                                           ^
In file included from /usr/include/c++/6/cstdlib:75:0,
                 from /usr/include/c++/6/ext/string_conversions.h:41,
                 from /usr/include/c++/6/bits/basic_string.h:5417,
                 from /usr/include/c++/6/string:52,
                 from src/gl/shader.h:3,
                 from src/sandbox.h:3,
                 from src/sandbox.cpp:1:
/usr/include/stdlib.h:735:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
            ^~~
In file included from /usr/include/c++/6/ext/string_conversions.h:41:0,
                 from /usr/include/c++/6/bits/basic_string.h:5417,
                 from /usr/include/c++/6/string:52,
                 from src/gl/shader.h:3,
                 from src/sandbox.h:3,
                 from src/sandbox.cpp:1:
/usr/include/c++/6/cstdlib:180:3: note: candidate: long long int std::abs(long long int)
   abs(long long __x) { return __builtin_llabs (__x); }
   ^~~
/usr/include/c++/6/cstdlib:172:3: note: candidate: long int std::abs(long int)
   abs(long __i) { return __builtin_labs(__i); }
   ^~~
Makefile:60: recipe for target 'src/sandbox.o' failed
make: *** [src/sandbox.o] Error 1

```

