### PR TITLE
Fix timeout for shaders without u_time uniform

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1236,6 +1236,12 @@ int main(int argc, char **argv){
         // Update
         updateGL();
 
+        // Calculate if timeout required
+        if ( timeLimit >= 0.0 && getTime() >= timeLimit ) {
+            timeOut = true;
+            sandbox.screenshotFile = outputFile;
+        }
+
         glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
         // Something change??
@@ -1247,15 +1253,9 @@ int main(int argc, char **argv){
         }
 
         // If nothing in the scene change skip the frame and try to keep it at 60fps
-        if (!fullFps && !sandbox.haveChange()) {
+        if (!timeOut && !fullFps && !sandbox.haveChange()) {
             usleep( micro_wait );
             continue;
-        }
-
-        
-        if ( timeLimit >= 0.0 && getTime() >= timeLimit ) {
-            timeOut = true;
-            sandbox.screenshotFile = outputFile;
         }
 
         // Draw Scene


### PR DESCRIPTION
Move timeout calculation higher in loop, and use it to determine whether to bypass drawing.

Fixes #142