### PR TITLE
Fix error message line number off by 1

### DIFF
--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -157,7 +157,7 @@ GLuint Shader::compileShader(const std::string& _src, GLenum _type, bool _verbos
         std::cout << _src << std::endl;
     }
 
-    prolog += "#line 1\n";
+    prolog += "#line 0\n";
 
     const GLchar* sources[2] = {
         (const GLchar*) prolog.c_str(),


### PR DESCRIPTION
The line number in an error message after "Errors while compiling fragment shader:" previously was off by 1.

This simple change fixes the issue.
