### PR TITLE
Revert "Removed glfw submodule"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "include/glfw"]
+	path = include/glfw
+	url = https://github.com/glfw/glfw


### PR DESCRIPTION
This reverts commit 70000e899112687694db60120014d088c1a347a0 because
it breaks vs2019 compilation.

Without this patch I was receiving

```
"C:\Users\...\Documents\work\glslViewer\glslViewer.sln" (default target) (1) ->
"C:\Users\...\Documents\work\glslViewer\glslViewer.vcxproj" (default target) (2) ->
(ClCompile target) ->
  C:\Users\...\Documents\work\glslViewer\src\window.cpp(39,10): fatal error C1083: Cannot open include file: 'GLFW/glfw3.h': No such file or directory [C:\Users\...\Documents\work\glslViewer\glslViewer.vcxproj]

    140 Warning(s)
    1 Error(s)

Time Elapsed 00:00:19.02
```

I tried doing the `git submodule update --init` suggested in the tutorial of how to compile but it did nothing because of the commit. 

The other option to solve this is manually cloning the repo, so if that's what you'd agree on, I'll update the tutorial on how to compile it for Windows.