### PR TITLE
added include for 'iterator' library

### DIFF
--- a/src/types/list.cpp
+++ b/src/types/list.cpp
@@ -1,5 +1,5 @@
 #include "list.h"
-
+#include <iterator>
 #include <algorithm>
 
 List merge(const List &_A,const List &_B) {


### PR DESCRIPTION
Visual Studio 2019 generates a compilation error: "back_inserter is not a member of std" which is resolved by explicitly including the iterator library. 

For reference >> https://github.com/erengy/anitomy/issues/2