### PR TITLE
Makefile: add more RPI4 revisions for fake_kms driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ LIBAV ?= not_defined
 
 ifneq ("$(wildcard /opt/vc/include/bcm_host.h)","")
 	PLATFORM = RPI
-	ifeq ($(shell cat /proc/cpuinfo | grep 'Revision' | awk '{print $$3}' ), c03111)
+	RPI_REVISION = $(shell cat /proc/cpuinfo | grep 'Revision' | awk '{print $$3}')
+	ifeq ($(RPI_REVISION),$(filter $(RPI_REVISION),a03111 b03111 b03112 b03114 c03111 c03112 c03114 d03114))
 		ifeq ($(DRIVER),not_defined)
 			DRIVER = fake_kms
 		endif


### PR DESCRIPTION
makes RPI fake_kms driver defined
as default one for more RPI4 devices.

Signed-off-by: bespsm <dkc.sergey.88@hotmail.com>


all revisions can be checked here: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md

PR solves following issue: https://github.com/patriciogonzalezvivo/glslViewer/issues/162
