### PR TITLE
textureStreamOMX: make LEGACY-driver specific

### DIFF
--- a/src/gl/textureStreamOMX.cpp
+++ b/src/gl/textureStreamOMX.cpp
@@ -1,6 +1,6 @@
 #include "textureStreamOMX.h"
 
-#ifdef PLATFORM_RPI
+#ifdef DRIVER_LEGACY
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/gl/textureStreamOMX.h
+++ b/src/gl/textureStreamOMX.h
@@ -2,7 +2,7 @@
 
 #include "textureStream.h"
 
-#ifdef PLATFORM_RPI
+#ifdef DRIVER_LEGACY
 
 #include <thread>
 

--- a/src/uniforms.cpp
+++ b/src/uniforms.cpp
@@ -315,6 +315,7 @@ bool Uniforms::addStreamingTexture( const std::string& _name, const std::string&
             else
                 delete tex;
         }
+#ifdef DRIVER_LEGACY
         else if ( haveExt(_url,"h264") || haveExt(_url,"H264") ) {
             TextureStreamOMX* tex = new TextureStreamOMX();
 
@@ -335,6 +336,7 @@ bool Uniforms::addStreamingTexture( const std::string& _name, const std::string&
             else
                 delete tex;
         }
+#endif
 #endif
         else {
 #ifdef SUPPORT_FOR_LIBAV


### PR DESCRIPTION
making textureStreamOMX LEGACY RPI driver
specific solves following issues:
* on RPI4 solves build issue, "ilclient.h not
found"
* on RPI4 for *.h264 files is used
TextureStreamAV object (textureStreamOMX is
not supported by FKMS driver)

Signed-off-by: bespsm <dkc.sergey.88@hotmail.com>