### PR TITLE
Show/hide mouse cursor on mouse enter/leave.

### DIFF
--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -978,7 +978,7 @@ void Sandbox::renderUI() {
         }
     }
 
-    if (cursor) {
+    if (cursor && getMouseEntered()) {
         if (m_cross_vbo == nullptr) 
             m_cross_vbo = cross(glm::vec3(0.0, 0.0, 0.0), 10.).getVbo();
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -18,6 +18,7 @@
 const std::string appTitle = "glslViewer";
 static glm::mat4 orthoMatrix;
 typedef struct {
+    bool      entered;
     float     x,y;
     int       button;
     float     velX,velY;
@@ -466,6 +467,11 @@ void initGL (glm::ivec4 &_viewport, WindowStyle _style) {
             onScroll(-yoffset * fPixelDensity);
         });
 
+        // callback when the mouse cursor enters/leaves
+        glfwSetCursorEnterCallback(window, [](GLFWwindow* _window, int entered) {
+            mouse.entered = (bool)entered;
+        });
+
         // callback when the mouse cursor moves
         glfwSetCursorPosCallback(window, [](GLFWwindow* _window, double x, double y) {
             // Convert x,y to pixel coordinates relative to viewport.
@@ -876,4 +882,8 @@ int getMouseButton(){
 
 glm::vec4 getMouse4() {
     return mouse4;
+}
+
+bool getMouseEntered(){
+    return mouse.entered;
 }

--- a/src/window.h
+++ b/src/window.h
@@ -49,6 +49,7 @@ float getMouseVelY();
 glm::vec2 getMouseVelocity();
 int getMouseButton();
 glm::vec4 getMouse4();
+bool getMouseEntered();
 
 // EVENTS
 //----------------------------------------------


### PR DESCRIPTION
This adresses the issue that after the mouse leaves the window the cursor is still drawn at the last recorded position.