### PR TITLE
Add initial audio support (Linux, RPI 3B+ 4B)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "include/glfw"]
 	path = include/glfw
 	url = https://github.com/glfw/glfw
+[submodule "include/miniaudio"]
+	path = include/miniaudio
+	url = https://github.com/mackron/miniaudio

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($(PLATFORM), RPI)
 		ILCLIENT = $(ILCLIENT_DIR)/libilclient.a
 		INCLUDES += -I$(ILCLIENT_DIR)
 		LDFLAGS += -L$(ILCLIENT_DIR) \
-					-lilclient
+					-lilclient -ldl
 		EXE_DEPS += $(ILCLIENT)
 
 	else ifeq ($(DRIVER),fake_kms)
@@ -61,7 +61,7 @@ ifeq ($(PLATFORM), RPI)
 		INCLUDES += -I/usr/include/libdrm \
 					-I/usr/include/GLES2
 		LDFLAGS +=  -ldrm -lgbm \
-					-lGLESv2 -lEGL
+					-lGLESv2 -lEGL -ldl
 	
 	else ifeq ($(DRIVER),glfw)
 		CFLAGS += -DDRIVER_GLFW $(shell pkg-config --cflags glfw3 glu gl)

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ifeq ($(PLATFORM), RPI)
 		INCLUDES += -I$(ILCLIENT_DIR)
 		LDFLAGS += -L$(ILCLIENT_DIR) \
 					-lilclient -ldl
-		EXE_DEPS += $(ILCLIENT)
+		DEPS += $(ILCLIENT)
 
 	else ifeq ($(DRIVER),fake_kms)
 		CFLAGS += -DDRIVER_FAKE_KMS
@@ -93,6 +93,9 @@ endif
 ifeq ($(LIBAV),true)
 CFLAGS += -DSUPPORT_FOR_LIBAV $(shell pkg-config --cflags libavcodec libavformat libavfilter libavdevice libavutil libswscale)
 LDFLAGS += $(shell pkg-config --libs libavcodec libavformat libavfilter libavdevice libavutil libswscale)
+MINIAUDIO = include/miniaudio/miniaudio.h
+HEADERS += ${MINIAUDIO}
+DEPS += ${MINIAUDIO}
 endif
 
 all: $(EXE)
@@ -101,11 +104,15 @@ all: $(EXE)
 	@echo $@
 	$(CXX) $(CFLAGS) $(INCLUDES) -g -c $< -o $@ -Wno-deprecated-declarations
 
-$(EXE): $(OBJECTS) $(HEADERS) $(EXE_DEPS)
+$(EXE): $(DEPS) $(OBJECTS) $(HEADERS)
 	$(CXX) $(CFLAGS) $(OBJECTS) $(LDFLAGS) -rdynamic -o $@
 
 ${ILCLIENT}:
 	$(MAKE) -C $(ILCLIENT_DIR)
+
+${MINIAUDIO}:
+	@echo "fetch miniaudio library"
+	@git submodule update --init include/miniaudio/
 
 clean:
 	@rm -rvf $(EXE) src/*.o src/*/*.o include/*/*.o include/*/*/*.o include/*/*/*/*.o *.dSYM 

--- a/examples/2D/00_tests/Makefile
+++ b/examples/2D/00_tests/Makefile
@@ -24,3 +24,6 @@ test_out_jpg:
 
 test_out_hdr:
 	glslViewer test.frag in.png -E screenshot,out.hdr
+
+test_audio:
+	glslViewer test_audio.frag --audio

--- a/examples/2D/00_tests/test_audio.frag
+++ b/examples/2D/00_tests/test_audio.frag
@@ -1,0 +1,28 @@
+// Created by Sergei B (https://github.com/bespsm)
+// Example of basic audio wave and frequency data usage.
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform vec2 u_resolution;
+uniform sampler2D u_tex0;
+
+void main (void) {
+
+    vec2 uv = gl_FragCoord.xy/u_resolution.xy;
+
+    // Frequency.
+    float fft = texture2D(u_tex0, vec2(uv.x, 0.)).x;
+
+    // Volume.
+    float vol = texture2D(u_tex0, vec2(uv.x, 0.)).y;
+
+    vec3 col = vec3(0.0);
+    col += 1.0 - smoothstep( 0.0, 0.010, abs(vol - uv.y) );
+    col += 1.0 - smoothstep( 0.0, 0.030, abs(fft - uv.y) );
+
+    col = pow( col, vec3(1.0,0.5,2.0) );
+
+    gl_FragColor = vec4(col,1.0);
+}

--- a/src/gl/textureAudio.cpp
+++ b/src/gl/textureAudio.cpp
@@ -1,0 +1,157 @@
+#include "textureAudio.h"
+
+#include <iostream>
+#include <mutex>
+
+#ifdef SUPPORT_FOR_LIBAV
+
+#define MA_NO_DECODING 
+#define MA_NO_ENCODING 
+#define MA_NO_WAV
+#define MA_NO_FLAC
+#define MA_NO_MP3
+#define MA_NO_GENERATION
+#define MINIAUDIO_IMPLEMENTATION
+
+extern "C" {
+#include <libavcodec/avfft.h>
+#include <libavutil/mem.h>
+#include "miniaudio/miniaudio.h"
+}
+
+ma_device_config a_deviceConfig;
+ma_device a_device;
+static RDFTContext *ctx;
+
+std::mutex mtx;
+
+void data_collect_callback(ma_device* pDevice, void* pOutput, const void* pInput, ma_uint32 frameCount) {
+
+    std::vector<uint8_t> * m_buffer = (std::vector<uint8_t>*)pDevice->pUserData;
+    uint8_t * m_buffer_wr = m_buffer->data();
+    size_t m_buf_len = m_buffer->size();
+
+    assert(m_buffer_wr != nullptr);
+
+    std::lock_guard<std::mutex> lock(mtx);
+
+    // shift left buffer's data to the number of new samples
+    memmove(m_buffer_wr, m_buffer_wr+frameCount, m_buf_len-frameCount);
+    memcpy(m_buffer_wr + m_buf_len-frameCount, pInput, frameCount);
+    (void)pOutput;
+}
+
+TextureAudio::TextureAudio(): TextureStream() {
+    // texture size
+    m_width = 256;
+    m_height = 1;
+    m_texture.resize(m_width * m_height * 4, 0);
+    m_dft_buffer = (float*)av_malloc_array(sizeof(float), m_buf_len);
+    m_buffer_wr.resize(m_buf_len, 0);
+    m_buffer_re.resize(m_buf_len, 0);
+}
+
+TextureAudio::~TextureAudio() {
+    this->clear();
+}
+
+bool TextureAudio::load() {
+    // set up audio format
+    a_deviceConfig = ma_device_config_init(ma_device_type_capture);
+    a_deviceConfig.capture.format   = ma_format_u8;
+    a_deviceConfig.capture.channels = 1;
+    a_deviceConfig.sampleRate       = 44100;
+    a_deviceConfig.dataCallback     = data_collect_callback;
+    a_deviceConfig.pUserData        = &m_buffer_wr;
+
+    // init default capture device
+    if (ma_device_init(NULL, &a_deviceConfig, &a_device) != MA_SUCCESS) {
+        std::cout << "Failed to initialize capture device." << std::endl;
+        return false;
+    }
+
+    // start capture device
+    if (ma_device_start(&a_device) != MA_SUCCESS) {
+        ma_device_uninit(&a_device);
+        std::cout << "Failed to start device."  << std::endl;
+        return false;
+    }
+
+    // init dft calculator
+    ctx = av_rdft_init((int) log2(m_buf_len), DFT_R2C);
+    if (!ctx) {
+        std::cout << "Failed to init dft calculator."  << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool TextureAudio::update() {
+
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        m_buffer_re = m_buffer_wr;
+    }
+
+    // copy amplitude values to GREEN pixels
+    for (int i = 0; i < m_width; i++) {
+        m_texture[1+i*4] = m_buffer_re.at(m_buf_len - m_width + i);
+    }
+
+    // prerare samples for dtf
+    for (int i = 0; i < m_buf_len; i++) {
+        // hann window
+        double window_modifier = (0.5 * (1 - cos(2 * M_PI * i / (m_buf_len - 1))));
+        // scale value from 0-255 to -1.0-+1.0
+        float value = (float)(window_modifier * ((m_buffer_re.at(i)) / 127.0f - 1.0f));
+        // limit values
+        if (value > 1.0) value = 1.0;
+        if (value < -1.0) value = -1.0;
+        m_dft_buffer[i] = value;
+    }
+
+    av_rdft_calc(ctx, m_dft_buffer);
+
+    // copy frequency values to RED pixels
+    for (int i = 0; i < m_width; i++) {
+        
+        // magnitude
+        float im = m_dft_buffer[i*2];
+        float re = m_dft_buffer[i*2 + 1];
+        float mag = sqrt(im * im + re * re);
+
+        // experimental scale factor
+        float mag_scaled = sqrt(mag) * 50;
+
+        // limit values
+        // if (mag_scaled > 255.0) mag_scaled = 255.0;
+        // if (mag_scaled < 0.0) mag_scaled = 0.0;
+
+        uint8_t mag_uint8 = mag_scaled;
+
+        auto prev_value = m_texture[4*(i)];
+
+        // failing effect for decreasing value
+        double decr_factor = 0.97;
+        if (prev_value > mag_uint8) {
+            m_texture[i*4] = prev_value * decr_factor;
+        }
+        else {
+            m_texture[i*4] = mag_uint8;
+        }
+    }
+    Texture::load(m_width, m_height, 4, 8, &m_texture[0]);
+    return true;
+}
+
+void TextureAudio::clear() {
+    ma_device_uninit(&a_device);
+
+   if (ctx) {
+        av_rdft_end(ctx); 
+    }
+    av_free(m_dft_buffer);
+}
+
+#endif

--- a/src/gl/textureAudio.h
+++ b/src/gl/textureAudio.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef SUPPORT_FOR_LIBAV
+
+#include "textureStream.h"
+#include <vector>
+
+class TextureAudio : public TextureStream {
+public:
+    TextureAudio();
+    virtual ~TextureAudio();
+
+    virtual bool    load();
+    virtual bool    update();
+    virtual void    clear();
+private:
+    static const int m_buf_len = 1024;
+    std::vector<uint8_t> m_buffer_wr, m_buffer_re, m_texture;
+    float* m_dft_buffer = nullptr;
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,6 +87,7 @@ void printUsage(char * executableName) {
     std::cerr << "// [<texture>.(png/tga/jpg/bmp/psd/gif/hdr/mov/mp4/rtsp/rtmp/etc)] - load and assign texture to uniform order" << std::endl;
     std::cerr << "// [-vFlip] - all textures after will be flipped vertically" << std::endl;
     std::cerr << "// [--video <video_device_number>] - open video device allocated wit that particular id" << std::endl;
+    std::cerr << "// [--audio] - open default capture device allocated as sampler2D texture with particular id" << std::endl;
     std::cerr << "// [-<uniformName> <texture>.(png/tga/jpg/bmp/psd/gif/hdr)] - add textures associated with different uniform sampler2D names" << std::endl;
     std::cerr << "// [-C <enviromental_map>.(png/tga/jpg/bmp/psd/gif/hdr)] - load a environmental map as cubemap" << std::endl;
     std::cerr << "// [-c <enviromental_map>.(png/tga/jpg/bmp/psd/gif/hdr)] - load a environmental map as cubemap but hided" << std::endl;
@@ -852,6 +853,10 @@ int main(int argc, char **argv){
                     argument.rfind("rtsp://", 0) == 0 ||
                     argument.rfind("rtmp://", 0) == 0) {
             if ( sandbox.uniforms.addStreamingTexture("u_tex"+toString(textureCounter), argument, vFlip, false) )
+                textureCounter++;
+        }
+        else if ( argument == "--audio" || argument == "-a" ) {
+            if ( sandbox.uniforms.addAudioTexture("u_tex"+toString(textureCounter), sandbox.verbose) )
                 textureCounter++;
         }
         else if ( argument == "-c" || argument == "-sh" ) {

--- a/src/uniforms.cpp
+++ b/src/uniforms.cpp
@@ -49,7 +49,7 @@ UniformFunction::UniformFunction(const std::string &_type, std::function<void(Sh
 
 // UNIFORMS
 
-Uniforms::Uniforms(): cubemap(nullptr), m_change(false) {
+Uniforms::Uniforms(): cubemap(nullptr), m_change(false), m_is_audio_init(false) {
 
     // set the right distance to the camera
     // Set up camera
@@ -370,6 +370,32 @@ bool Uniforms::addStreamingTexture( const std::string& _name, const std::string&
 
     }
     return false;
+}
+
+bool Uniforms::addAudioTexture(const std::string& _name, bool _verbose) {
+
+#ifdef SUPPORT_FOR_LIBAV
+    // already init
+    if (m_is_audio_init) return false;
+
+    auto tex = new TextureAudio();
+
+    // TODO: add configurable device
+    // TODO: add flipping mode for audio texture
+    if (tex->load()) {
+
+        if (_verbose) {
+            std::cout << "//    loaded audio texture: " << std::endl;
+            std::cout << "//    uniform sampler2D   " << _name  << ";"<< std::endl;
+        }
+            textures[ _name ] = (Texture*)tex;
+            streams[ _name ] = (TextureStream*)tex;
+            m_is_audio_init = true;
+            return true;
+    }
+    else
+#endif
+        return false;
 }
 
 void Uniforms::updateStreammingTextures() {

--- a/src/uniforms.h
+++ b/src/uniforms.h
@@ -9,6 +9,7 @@
 #include "gl/shader.h"
 #include "gl/texture.h"
 #include "gl/textureStream.h"
+#include "gl/textureAudio.h"
 
 #include "scene/light.h"
 #include "scene/camera.h"
@@ -54,6 +55,7 @@ public:
     bool                    addTexture( const std::string& _name, const std::string& _path, WatchFileList& _files, bool _flip = true, bool _verbose = true );
     bool                    addBumpTexture( const std::string& _name, const std::string& _path, WatchFileList& _files, bool _flip = true, bool _verbose = true );
     bool                    addStreamingTexture( const std::string& _name, const std::string& _url, bool _flip = true, bool _device = false, bool _verbose = true );
+    bool                    addAudioTexture( const std::string& _name, bool _verbose = true);
     void                    updateStreammingTextures();
 
     void                    setCubeMap( TextureCube* _cubemap );
@@ -100,6 +102,7 @@ public:
 
 protected:
     bool                    m_change;
+    bool                    m_is_audio_init;
 };
 
 


### PR DESCRIPTION
can be build with **make LIBAV=true** 
added one file library **miniaudio** - audio playback and capture library. (https://github.com/mackron/miniaudio)

tested on the following platforms:
- Linux platform with glfw drivers (works ok, in conjuction with  examples/2D/00_tests/test.frag as well) - tested with build-in microphone
- RPI 3B+ (works ok) - tested with 2 different usb soundcards 
- RPI 4B (CPU get overheated. PS: seems like it's common issue, other shaders overheat CPU, like examples/2D/00_tests/test.frag with in.png)  - tested with 2 different usb soundcards

@patriciogonzalezvivo please help me with testing on another platforms. For the testing can be used shaders from shadertoy using sampler2D texture:

frequency data can be taken with line:
`float fft = texture2D(u_texN, vec2(uv.x, 0.)).x;`
wave data can be taken with line:
`float vol = texture2D(u_texN, vec2(uv.x, 0.)).y;`

MR contains as well basic example. 
MR covers the issue: https://github.com/patriciogonzalezvivo/glslViewer/issues/61