### PR TITLE
memory-leaking: fix

### DIFF
--- a/src/gl/texture.cpp
+++ b/src/gl/texture.cpp
@@ -117,7 +117,7 @@ bool Texture::load(const std::string& _path, bool _vFlip) {
 
         unsigned char* pixels = loadPixels(_path, &m_width, &m_height, RGB_ALPHA, _vFlip);
         load(m_width, m_height, 4, 8, pixels);
-        delete pixels;
+        freePixels(pixels);
     }
 
     // PNG 1/2/4/8/16-bit-per-channel
@@ -130,11 +130,11 @@ bool Texture::load(const std::string& _path, bool _vFlip) {
         // If we are in a Raspberry Pi don't take the risk of loading a 16bit image
         unsigned char* pixels = loadPixels(_path, &m_width, &m_height, RGB_ALPHA, _vFlip);
         load(m_width, m_height, 4, 8, pixels);
-        delete pixels;
+        freePixels(pixels);
 #else
         uint16_t* pixels = loadPixels16(_path, &m_width, &m_height, RGB_ALPHA, _vFlip);
         load(m_width, m_height, 4, 16, pixels);
-        delete pixels;
+        freePixels(pixels);
 #endif
     }
 
@@ -142,7 +142,7 @@ bool Texture::load(const std::string& _path, bool _vFlip) {
     else if (ext == "hdr" || ext == "HDR") {
         float* pixels = loadPixelsHDR(_path, &m_width, &m_height, _vFlip);
         load(m_width, m_height, 3, 32, pixels);
-        delete pixels;
+        freePixels(pixels);
     }
 
     m_path = _path;

--- a/src/io/fs.cpp
+++ b/src/io/fs.cpp
@@ -55,7 +55,9 @@ const char* realpath(const char* str, void*)
 }
 #endif 
 std::string getAbsPath(const std::string& _path) {
-    std::string abs_path = realpath(_path.c_str(), NULL);
+    char * real_path = realpath(_path.c_str(), NULL);
+    std::string abs_path(real_path);
+    free(real_path);
     std::size_t found = abs_path.find_last_of("\\/");
     if (found) return abs_path.substr(0, found);
     else return "";

--- a/src/io/gltf.cpp
+++ b/src/io/gltf.cpp
@@ -519,3 +519,7 @@ bool savePixelsHDR(const std::string& _path, float* _pixels, int _width, int _he
     }
     return true;
 }
+
+void freePixels(void *pixels) {
+    stbi_image_free(pixels);
+}

--- a/src/io/pixels.h
+++ b/src/io/pixels.h
@@ -19,6 +19,7 @@ bool            savePixelsHDR(const std::string& _path, float* _pixels, int _wid
 unsigned char*  loadPixels(const std::string& _path, int *_width, int *_height, Channels _channels = RGB, bool _vFlip = true);
 uint16_t *      loadPixels16(const std::string& _path, int *_width, int *_height, Channels _channels = RGB, bool _vFlip = true);
 float*          loadPixelsHDR(const std::string& _path, int *_width, int *_height, bool _vFlip = true);
+void            freePixels(void *pixels);
 
 template<typename T>
 void rescalePixels(const T* _src, int _srcWidth, int _srcHeight, int _srcChannels, int _dstWidth, int _dstHeight, T* _dst) {


### PR DESCRIPTION
provided fix for:
* stb_image_alocated objects,
* realpath alocated objects


valgrind logs:
.....
==144674== 4,096 bytes in 1 blocks are definitely lost in loss record 2,203 of 2,211
==144674==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==144674==    by 0x674E936: realpath@@GLIBC_2.3 (canonicalize.c:78)
==144674==    by 0x455AEF: getAbsPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (fs.cpp:58)
==144674==    by 0x45610C: loadFromPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >*) (fs.cpp:113)
==144674==    by 0x34B387: Sandbox::setup(std::vector<WatchFile, std::allocator<WatchFile> >&, std::vector<Command, std::allocator<Command> >&) (sandbox.cpp:492)
==144674==    by 0x33ACED: main (main.cpp:955)
.....
==144674== 1 errors in context 1 of 24:
==144674== Mismatched free() / delete / delete []
==144674==    at 0x483CFBF: operator delete(void*) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==144674==    by 0x45EC8E: Texture::load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (texture.cpp:137)
==144674==    by 0x2EEF7B: Uniforms::addTexture(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<WatchFile, std::allocator<WatchFile> >&, bool, bool) (uniforms.cpp:201)
==144674==    by 0x3396E0: main (main.cpp:833)
==144674==  Address 0x1eea3040 is 0 bytes inside a block of size 2,097,152 alloc'd
==144674==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==144674==    by 0x36A6E6: stbi__malloc(unsigned long) (stb_image.h:888)
==144674==    by 0x36AD9F: stbi__convert_8_to_16(unsigned char*, int, int, int) (stb_image.h:1068)
==144674==    by 0x36B23E: stbi__load_and_postprocess_16bit(stbi__context*, int*, int*, int*, int) (stb_image.h:1150)
==144674==    by 0x36B528: stbi_load_from_file_16 (stb_image.h:1246)
==144674==    by 0x36B5EF: stbi_load_16 (stb_image.h:1259)
==144674==    by 0x3AF214: loadPixels16(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int*, int*, Channels, bool) (gltf.cpp:433)
==144674==    by 0x45EC3D: Texture::load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (texture.cpp:135)
==144674==    by 0x2EEF7B: Uniforms::addTexture(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<WatchFile, std::allocator<WatchFile> >&, bool, bool) (uniforms.cpp:201)
==144674==    by 0x3396E0: main (main.cpp:833)
.......

