### PR TITLE
textureAudio: add non-default audio devices support

### DIFF
--- a/src/gl/textureAudio.cpp
+++ b/src/gl/textureAudio.cpp
@@ -1,4 +1,5 @@
 #include "textureAudio.h"
+#include "tools/text.h"
 
 #include <iostream>
 #include <mutex>
@@ -58,12 +59,20 @@ TextureAudio::~TextureAudio() {
     this->clear();
 }
 
-bool TextureAudio::load(bool verbose, int in_device_id) {
+bool TextureAudio::load(const std::string &_device_id_str, bool /*_vFlip*/) {
 
     ma_uint32 playbackDeviceCount = 0;
     ma_uint32 captureDeviceCount = 0;
     int default_device_id = -1;
-    ma_uint32 device_id = 0;
+    int device_id = 0;
+    int _device_id_int = -1;
+
+    if (isInt(_device_id_str)) {
+        _device_id_int = toInt(_device_id_str);
+    }
+    else {
+        std::cout << "Device id " << _device_id_str << " is incorrect, default device will be used.\n";
+    }
 
     if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS) {
         std::cout <<  "Failed to initialize context.\n";
@@ -76,16 +85,12 @@ bool TextureAudio::load(bool verbose, int in_device_id) {
         return false;
     }
 
-    if (verbose) {
-        std::cout << "Capture devices available\n";
-    }
+    std::cout << "Capture devices available\n";
     for (ma_uint32 iDevice = 0; iDevice < captureDeviceCount; ++iDevice) {
         if (pCaptureDeviceInfos[iDevice].isDefault == true) {
             default_device_id = iDevice;
         }
-        if (verbose) {
-            std::cout << "    " << iDevice << ": " << pCaptureDeviceInfos[iDevice].name << "\n";
-        }
+        std::cout << "    " << iDevice << ": " << pCaptureDeviceInfos[iDevice].name << "\n";
     }
 
     // there is no default (miniaudio bug) or no capture devices
@@ -95,22 +100,20 @@ bool TextureAudio::load(bool verbose, int in_device_id) {
         return false;
     }
 
-    if (in_device_id == -1) {
+    if (_device_id_int == -1) {
         device_id = default_device_id;
     }
-    else if (in_device_id < -1 || in_device_id > (captureDeviceCount - 1)) {
+    else if (_device_id_int < -1 || _device_id_int > int(captureDeviceCount - 1)) {
         // warning if non-default device id is incorrect
-        std::cout << "Device number " << in_device_id << " is incorrect, default device will be used.\n";
+        std::cout << "Device id " << _device_id_int << " is incorrect, default device will be used.\n";
         device_id = default_device_id;
     }
     else {
-        device_id = in_device_id;
+        device_id = _device_id_int;
     }
 
-    if (verbose) {
-        std::cout << "Loading capture device\n";
-        std::cout << "    " << device_id << ": " << pCaptureDeviceInfos[device_id].name << "\n";
-    }
+    std::cout << "Loading capture device\n";
+    std::cout << "    " << device_id << ": " << pCaptureDeviceInfos[device_id].name << "\n";
 
     // set up audio format
     a_deviceConfig = ma_device_config_init(ma_device_type_capture);

--- a/src/gl/textureAudio.cpp
+++ b/src/gl/textureAudio.cpp
@@ -22,6 +22,9 @@ extern "C" {
 ma_device_config a_deviceConfig;
 ma_device a_device;
 static RDFTContext *ctx;
+ma_context context;
+ma_device_info* pPlaybackDeviceInfos;
+ma_device_info* pCaptureDeviceInfos;
 
 std::mutex mtx;
 
@@ -55,9 +58,63 @@ TextureAudio::~TextureAudio() {
     this->clear();
 }
 
-bool TextureAudio::load(const std::string& _filepath, bool _vFlip) {
+bool TextureAudio::load(bool verbose, int in_device_id) {
+
+    ma_uint32 playbackDeviceCount = 0;
+    ma_uint32 captureDeviceCount = 0;
+    int default_device_id = -1;
+    ma_uint32 device_id = 0;
+
+    if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS) {
+        std::cout <<  "Failed to initialize context.\n";
+        return false;
+    }
+
+    if (ma_context_get_devices(&context, &pPlaybackDeviceInfos, &playbackDeviceCount, &pCaptureDeviceInfos, &captureDeviceCount) != MA_SUCCESS) {
+        std::cout << "Failed to retrieve device information.\n";
+        ma_context_uninit(&context);
+        return false;
+    }
+
+    if (verbose) {
+        std::cout << "Capture devices available\n";
+    }
+    for (ma_uint32 iDevice = 0; iDevice < captureDeviceCount; ++iDevice) {
+        if (pCaptureDeviceInfos[iDevice].isDefault == true) {
+            default_device_id = iDevice;
+        }
+        if (verbose) {
+            std::cout << "    " << iDevice << ": " << pCaptureDeviceInfos[iDevice].name << "\n";
+        }
+    }
+
+    // there is no default (miniaudio bug) or no capture devices
+    if (default_device_id == -1 || captureDeviceCount == 0) {
+        std::cout << "No capture devices available.\n";
+        ma_context_uninit(&context);
+        return false;
+    }
+
+    if (in_device_id == -1) {
+        device_id = default_device_id;
+    }
+    else if (in_device_id < -1 || in_device_id > (captureDeviceCount - 1)) {
+        // warning if non-default device id is incorrect
+        std::cout << "Device number " << in_device_id << " is incorrect, default device will be used.\n";
+        device_id = default_device_id;
+    }
+    else {
+        device_id = in_device_id;
+    }
+
+    if (verbose) {
+        std::cout << "Loading capture device\n";
+        std::cout << "    " << device_id << ": " << pCaptureDeviceInfos[device_id].name << "\n";
+    }
+
     // set up audio format
     a_deviceConfig = ma_device_config_init(ma_device_type_capture);
+    a_deviceConfig.capture.pDeviceID = &pCaptureDeviceInfos[device_id].id;
     a_deviceConfig.capture.format   = ma_format_u8;
     a_deviceConfig.capture.channels = 1;
     a_deviceConfig.sampleRate       = 44100;
@@ -65,7 +122,8 @@ bool TextureAudio::load(const std::string& _filepath, bool _vFlip) {
     a_deviceConfig.pUserData        = &m_buffer_wr;
 
     // init default capture device
-    if (ma_device_init(NULL, &a_deviceConfig, &a_device) != MA_SUCCESS) {
+    if (ma_device_init(&context, &a_deviceConfig, &a_device) != MA_SUCCESS) {
+        ma_context_uninit(&context);
         std::cout << "Failed to initialize capture device." << std::endl;
         return false;
     }
@@ -73,6 +131,7 @@ bool TextureAudio::load(const std::string& _filepath, bool _vFlip) {
     // start capture device
     if (ma_device_start(&a_device) != MA_SUCCESS) {
         ma_device_uninit(&a_device);
+        ma_context_uninit(&context);
         std::cout << "Failed to start device."  << std::endl;
         return false;
     }
@@ -80,6 +139,8 @@ bool TextureAudio::load(const std::string& _filepath, bool _vFlip) {
     // init dft calculator
     ctx = av_rdft_init((int) log2(m_buf_len), DFT_R2C);
     if (!ctx) {
+        ma_device_uninit(&a_device);
+        ma_context_uninit(&context);
         std::cout << "Failed to init dft calculator."  << std::endl;
         return false;
     }
@@ -147,6 +208,7 @@ bool TextureAudio::update() {
 
 void TextureAudio::clear() {
     ma_device_uninit(&a_device);
+    ma_context_uninit(&context);
 
    if (ctx) {
         av_rdft_end(ctx); 

--- a/src/gl/textureAudio.h
+++ b/src/gl/textureAudio.h
@@ -10,7 +10,7 @@ public:
     TextureAudio();
     virtual ~TextureAudio();
 
-    virtual bool    load(bool verbose, int device_id = -1);
+    virtual bool    load(const std::string &_path, bool _vFlip);
     virtual bool    update();
     virtual void    clear();
 private:

--- a/src/gl/textureAudio.h
+++ b/src/gl/textureAudio.h
@@ -10,7 +10,7 @@ public:
     TextureAudio();
     virtual ~TextureAudio();
 
-    virtual bool    load(const std::string& _filepath, bool _vFlip);
+    virtual bool    load(bool verbose, int device_id = -1);
     virtual bool    update();
     virtual void    clear();
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -857,14 +857,16 @@ int main(int argc, char **argv){
                 textureCounter++;
         }
         else if ( argument == "--audio" || argument == "-a" ) {
-            int device_id = -1; //default device id
-            if (++i < argc) {
-                argument = std::string(argv[i]);
-                if (isDigit(argument)) {
-                    device_id = toInt(argument);
+            std::string device_id = "-1"; //default device id
+            // device_id is optional argument, not iterate yet
+            if ((i + 1) < argc) {
+                argument = std::string(argv[i + 1]);
+                if (isInt(argument)) {
+                    device_id = argument;
+                    i++;
                 }
             }
-            if ( sandbox.uniforms.addAudioTexture("u_tex"+toString(textureCounter), device_id, true) )
+            if ( sandbox.uniforms.addAudioTexture("u_tex"+toString(textureCounter), device_id, vFlip, true) )
                 textureCounter++;
         }
         else if ( argument == "--holoplay" ) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ void printUsage(char * executableName) {
     std::cerr << "// [<texture>.(png/tga/jpg/bmp/psd/gif/hdr/mov/mp4/rtsp/rtmp/etc)] - load and assign texture to uniform order" << std::endl;
     std::cerr << "// [-vFlip] - all textures after will be flipped vertically" << std::endl;
     std::cerr << "// [--video <video_device_number>] - open video device allocated wit that particular id" << std::endl;
-    std::cerr << "// [--audio] - open default capture device allocated as sampler2D texture with particular id" << std::endl;
+    std::cerr << "// [--audio <capture_device_id>] - open audio capture device allocated as sampler2D texture. If id is not selected, default will be used" << std::endl;
     std::cerr << "// [-<uniformName> <texture>.(png/tga/jpg/bmp/psd/gif/hdr)] - add textures associated with different uniform sampler2D names" << std::endl;
     std::cerr << "// [-C <enviromental_map>.(png/tga/jpg/bmp/psd/gif/hdr)] - load a environmental map as cubemap" << std::endl;
     std::cerr << "// [-c <enviromental_map>.(png/tga/jpg/bmp/psd/gif/hdr)] - load a environmental map as cubemap but hided" << std::endl;
@@ -857,7 +857,14 @@ int main(int argc, char **argv){
                 textureCounter++;
         }
         else if ( argument == "--audio" || argument == "-a" ) {
-            if ( sandbox.uniforms.addAudioTexture("u_tex"+toString(textureCounter), true) )
+            int device_id = -1; //default device id
+            if (++i < argc) {
+                argument = std::string(argv[i]);
+                if (isDigit(argument)) {
+                    device_id = toInt(argument);
+                }
+            }
+            if ( sandbox.uniforms.addAudioTexture("u_tex"+toString(textureCounter), device_id, true) )
                 textureCounter++;
         }
         else if ( argument == "--holoplay" ) {

--- a/src/tools/text.cpp
+++ b/src/tools/text.cpp
@@ -44,6 +44,10 @@ bool isDigit(const std::string& _string) {
   return _string.find_first_not_of( "0123456789" ) == std::string::npos;
 }
 
+bool isInt(const std::string& _string) {
+  return _string.find_first_not_of( "0123456789-" ) == std::string::npos;
+}
+
 bool isFloat(const std::string& _string) {
     std::istringstream iss(_string);
     float dummy;

--- a/src/tools/text.h
+++ b/src/tools/text.h
@@ -32,6 +32,8 @@ bool beginsWith(const std::string& _stringA, const std::string& _stringB);
 
 bool isDigit(const std::string& _string);
 
+bool isInt(const std::string& _string);
+
 // Split a string into a vector of strings 
 std::vector<std::string> split(const std::string& _string, char _sep, bool _tolerate_empty = false);
 

--- a/src/uniforms.cpp
+++ b/src/uniforms.cpp
@@ -424,7 +424,7 @@ bool Uniforms::addStreamingTexture( const std::string& _name, const std::string&
     return false;
 }
 
-bool Uniforms::addAudioTexture(const std::string& _name, bool _verbose) {
+bool Uniforms::addAudioTexture(const std::string& _name, int device_id, bool _verbose) {
 
 #ifdef SUPPORT_FOR_LIBAV
     // already init
@@ -432,9 +432,8 @@ bool Uniforms::addAudioTexture(const std::string& _name, bool _verbose) {
 
     auto tex = new TextureAudio();
 
-    // TODO: add configurable device
     // TODO: add flipping mode for audio texture
-    if (tex->load("dummy load", false)) {
+    if (tex->load(_verbose, device_id)) {
 
         if (_verbose) {
             std::cout << "//    loaded audio texture: " << std::endl;

--- a/src/uniforms.cpp
+++ b/src/uniforms.cpp
@@ -424,7 +424,7 @@ bool Uniforms::addStreamingTexture( const std::string& _name, const std::string&
     return false;
 }
 
-bool Uniforms::addAudioTexture(const std::string& _name, int device_id, bool _verbose) {
+bool Uniforms::addAudioTexture(const std::string& _name, const std::string& device_id, bool _flip, bool _verbose) {
 
 #ifdef SUPPORT_FOR_LIBAV
     // already init
@@ -433,7 +433,7 @@ bool Uniforms::addAudioTexture(const std::string& _name, int device_id, bool _ve
     auto tex = new TextureAudio();
 
     // TODO: add flipping mode for audio texture
-    if (tex->load(_verbose, device_id)) {
+    if (tex->load(device_id, _flip)) {
 
         if (_verbose) {
             std::cout << "//    loaded audio texture: " << std::endl;

--- a/src/uniforms.h
+++ b/src/uniforms.h
@@ -55,7 +55,7 @@ public:
     bool                    addTexture( const std::string& _name, const std::string& _path, WatchFileList& _files, bool _flip = true, bool _verbose = true );
     bool                    addBumpTexture( const std::string& _name, const std::string& _path, WatchFileList& _files, bool _flip = true, bool _verbose = true );
     bool                    addStreamingTexture( const std::string& _name, const std::string& _url, bool _flip = true, bool _device = false, bool _verbose = true );
-    bool                    addAudioTexture( const std::string& _name, int device_id, bool _verbose = true);
+    bool                    addAudioTexture( const std::string& _name, const std::string& device_id, bool _flip = false, bool _verbose = true );
     void                    updateStreammingTextures();
 
     void                    setCubeMap( TextureCube* _cubemap );

--- a/src/uniforms.h
+++ b/src/uniforms.h
@@ -55,7 +55,7 @@ public:
     bool                    addTexture( const std::string& _name, const std::string& _path, WatchFileList& _files, bool _flip = true, bool _verbose = true );
     bool                    addBumpTexture( const std::string& _name, const std::string& _path, WatchFileList& _files, bool _flip = true, bool _verbose = true );
     bool                    addStreamingTexture( const std::string& _name, const std::string& _url, bool _flip = true, bool _device = false, bool _verbose = true );
-    bool                    addAudioTexture( const std::string& _name, bool _verbose = true);
+    bool                    addAudioTexture( const std::string& _name, int device_id, bool _verbose = true);
     void                    updateStreammingTextures();
 
     void                    setCubeMap( TextureCube* _cubemap );


### PR DESCRIPTION
* add optional argument to "--audio" parameter.
It specifies id of capture device.
If argument not provided, default capture device
will be selected.
* print all available capture devices and it's ids.

covers following request: https://github.com/patriciogonzalezvivo/glslViewer/issues/223