### PR TITLE
textureStreamAV: mismatched data free

### DIFF
--- a/src/gl/textureBump.cpp
+++ b/src/gl/textureBump.cpp
@@ -67,7 +67,7 @@ bool TextureBump::load(const std::string& _path, bool _vFlip) {
                 i++;
             }
         }
-        delete pixels;
+        freePixels(pixels);
 
         Texture::load(m_width, m_height, 4, 32, &result[0]);
     }

--- a/src/gl/textureCube.cpp
+++ b/src/gl/textureCube.cpp
@@ -342,7 +342,7 @@ bool TextureCube::load(const std::string &_path, bool _vFlip) {
             sh_samples += faces[i]->calculateSH(SH);
         }
 
-        delete[] data;
+        freePixels(data);
         for(int i = 0; i < 6; ++i) {
             delete[] faces[i]->data;
             delete faces[i];
@@ -394,7 +394,7 @@ bool TextureCube::load(const std::string &_path, bool _vFlip) {
             sh_samples += faces[i]->calculateSH(SH);
         }
 
-        delete[] data;
+        freePixels(data);
         for(int i = 0; i < 6; ++i) {
             delete[] faces[i]->data;
             delete faces[i];

--- a/src/gl/textureStreamAV.cpp
+++ b/src/gl/textureStreamAV.cpp
@@ -348,8 +348,8 @@ void  TextureStreamAV::clear() {
         avformat_free_context(av_format_ctx);
         // avformat_close_input(&av_format_ctx);
 
-    if (frame_data) 
-        delete frame_data;
+    if (frame_data)
+        free(frame_data);
 
     if (m_id != 0)
         glDeleteTextures(1, &m_id);


### PR DESCRIPTION
valgrind log:
==363065== Mismatched free() / delete / delete []
==363065==    at 0x484065D: operator delete[](void*) (vg_replace_malloc.c:938)
==363065==    by 0x25BDC5: clear (textureStreamAV.cpp:352)
==363065==    by 0x25BDC5: ~TextureStreamAV (textureStreamAV.cpp:68)
==363065==    by 0x25BDC5: TextureStreamAV::~TextureStreamAV() (textureStreamAV.cpp:69)
==363065==    by 0x17227E: Uniforms::clear() (uniforms.cpp:656)
==363065==    by 0x19AFE0: Sandbox::clear() (sandbox.cpp:1207)
==363065==    by 0x193E5D: onExit() (main.cpp:1084)
==363065==    by 0x161A5D: main (main.cpp:1026)
==363065==  Address 0x1f2a9080 is 0 bytes inside a block of size 8,294,400 alloc'd
==363065==    at 0x4841818: memalign (vg_replace_malloc.c:1265)
==363065==    by 0x4841936: posix_memalign (vg_replace_malloc.c:1429)
==363065==    by 0x25BF92: TextureStreamAV::load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (textureStreamAV.cpp:180)
==363065==    by 0x17650B: Uniforms::addStreamingTexture(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool) (uniforms.cpp:379)
==363065==    by 0x163C0B: main (main.cpp:859)

stackoverflow solution:
https://stackoverflow.com/a/10609996