### PR TITLE
attempt to find the Looking Glass display ID when more than two 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,7 @@ void printUsage(char * executableName) {
     std::cerr << "// [--headless] - headless rendering. Very useful for making images or benchmarking." << std::endl;
     std::cerr << "// [--nocursor] - hide cursor" << std::endl;
     std::cerr << "// [--fxaa] - set FXAA as postprocess filter" << std::endl;
-    std::cerr << "// [--holoplay <0/1/2>] - HoloPlay volumetric postprocess" << std::endl;
+    std::cerr << "// [--holoplay <[0..7]>] - HoloPlay volumetric postprocess (Looking Glass Model)" << std::endl;
     std::cerr << "// [-I<include_folder>] - add an include folder to default for #include files" << std::endl;
     std::cerr << "// [-D<define>] - add system #defines directly from the console argument" << std::endl;
     std::cerr << "// [-p <osc_port>] - open OSC listening port" << std::endl;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -432,12 +432,29 @@ void initGL (glm::ivec4 &_viewport, WindowStyle _style) {
 
             int count;
             GLFWmonitor **monitors = glfwGetMonitors(&count);
-            const GLFWvidmode* mode = glfwGetVideoMode(monitors[1]);
+            int monitorID = 1;
+
+            if(count > 2){ //if we have more than 2 screens, try and find the looking glass screen ID 
+                monitorID = -1;
+                for (int i = 0; i < count; i++){
+                    const char* name = glfwGetMonitorName(monitors[i]);
+                    if(name && strlen(name) >= 3){ // if monitor name is > than 3 chars
+                        if(name[0] == 'L' && name[1] == 'K' && name[2] == 'G'){ // found a match for the looking glass screen
+                            monitorID = i;
+                        }
+                    }
+                }
+                if(monitorID == -1){ //could not find the looking glass screen
+                    monitorID = 1;
+                }
+            }
+
+            const GLFWvidmode* mode = glfwGetVideoMode(monitors[monitorID]);
             _viewport.z = mode->width;
             _viewport.w = mode->height;
 
             int xpos, ypos;
-            glfwGetMonitorPos(monitors[1], &xpos, &ypos);
+            glfwGetMonitorPos(monitors[monitorID], &xpos, &ypos);
             window = glfwCreateWindow(_viewport.z, _viewport.w, appTitle.c_str(), NULL, NULL);
             
             glfwSetWindowPos(window, xpos, ypos);


### PR DESCRIPTION
displays are connected.

I am submitting this because I had trouble using my Looking Glass Portrait with my three monitor setup.

The idea behind this is to not assume that the LookingGlass display will be on GLFW monitor ID=1, and instead try and find the right ID by looking at each display name. Note that this won't work well if you have more than one LookingGlass plugged in.

As a side note, the hologram did not look right until I manually edited all the hardcoded values in sandbox.cpp (holoplay_pitch, holoplay_slope, etc) to match mine. It would be nice to provide these values from the CLI (maybe allow the user to provide a path to your "visual.json" file).