### PR TITLE
Windows: fix potential issue with std::merge

### DIFF
--- a/src/types/list.cpp
+++ b/src/types/list.cpp
@@ -3,6 +3,15 @@
 #include <algorithm>
 
 List merge(const List &_A,const List &_B) {
+
+#ifdef PLATFORM_WINDOWS
+    // std::merge on Windows would expect _A and _B to be already sorted to work
+    List rta(_A);
+
+    rta.insert(rta.begin(), _B.begin(), _B.end());      // rta = _A + _B
+    rta.erase(std::unique(rta.begin(), rta.end()), rta.end());  // remove duplicates
+    std::sort(rta.begin(), rta.end());  // sort the resulting List
+#else
     List rta;
     
     std::merge( _A.begin(), _A.end(),
@@ -12,7 +21,7 @@ List merge(const List &_A,const List &_B) {
     std::sort( rta.begin(), rta.end() );
 
     rta.erase(std::unique(rta.begin(), rta.end()), rta.end());    
-
+#endif
     return rta;
 }
 


### PR DESCRIPTION
Windows: Apparently std::merge requires that inputs are already sorted.
Quick fix so it works as intended