### PR TITLE
Fixing link for Console IN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ GlslViewer gives support to:
     * [Loading Textures](https://github.com/patriciogonzalezvivo/glslViewer/wiki/Using-GlslViewer#3-loading-textures)
     * [Audio and video Textures](https://github.com/patriciogonzalezvivo/glslViewer/wiki/Audio-and-Video-Textures)
     * [Other arguments](https://github.com/patriciogonzalezvivo/glslViewer/wiki/Using-GlslViewer#4-other-arguments)
-    * [Console IN commands](https://github.com/patriciogonzalezvivo/glslViewer/wiki/Using-GlslViewer#console-in-commands)
+    * [Console IN commands](https://github.com/patriciogonzalezvivo/glslViewer/wiki/Interacting-with-GlslViewer)
 
 * Convention: 
     * [Defines](https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES)


### PR DESCRIPTION
I believe this used to be a section of "Using GlslViewer" wiki page and now it looks like it's its own url!