### PR TITLE
Fix windows build in ncurses branch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1579,8 +1579,8 @@ void cinWatcherThread() {
     endwin();
 
     #else
-    // Commands comming from the console IN
-    
+    // Commands coming from the console IN
+    std::string cmd;
     std::cout << "// > ";
     while (std::getline(std::cin, cmd)) {
         commandsRun(cmd, commandsMutex);


### PR DESCRIPTION
Adds a declaration which was missing in the non-`SUPPORT_NCURSES` branch of `cinWatcherThread()`