### PR TITLE
Fixed missing import preventing build on Arch Linux

### DIFF
--- a/src/tools/text.cpp
+++ b/src/tools/text.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 #include <regex>
-
+#include <cstring>
 #include "ada/tools/text.h"
 
 // Quickly determine if a shader program contains the specified identifier.


### PR DESCRIPTION
Added a missing import in `src/tools/text.cpp`.

I attempted to build glslViewer from source on Arch Linux, and encountered the following error when running `make`. I followed the steps outlined in this repository's wiki exactly.

![image](https://user-images.githubusercontent.com/88111643/169381335-49fd4233-0085-4beb-b0b3-061bd24ba937.png)

Turns out, all that was needed was a `cstring` import.

![image](https://user-images.githubusercontent.com/88111643/169381670-f1f5a934-57dc-4caa-bffe-27392718c2af.png)