### PR TITLE
Hide glslViewer from desktop menus

### DIFF
--- a/assets/glslViewer.desktop
+++ b/assets/glslViewer.desktop
@@ -11,4 +11,4 @@ Icon=/usr/share/pixmaps/glslViewer.png
 Terminal=true
 MimeType=model/mesh;model/x-ply;model/x-obj;model/x-glb;model/x-gltf;
 Categories=Graphics;3DGraphics;Viewer;
-NoDisplay=false
+NoDisplay=true


### PR DESCRIPTION
Starting glslViewer requires passing shader filenames as command line 
arguments, otherwise it will exit immediately. Launching glslViewer 
via the desktop entry (i.e. from desktop environment menu) can not 
pass filenames as arguments, and therefore it fails without any 
message to the user.

Hide the unusable application entry from desktop menus. The desktop 
entry is still useful for opening associated MIME types from e.g. 
file managers.

This is intended usage of the `NoDisplay` desktop entry key, see https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys.