### PR TITLE
Fix: Update .gitmodules to a public https-url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/vera"]
 	path = deps/vera
-	url = git@github.com:patriciogonzalezvivo/vera.git
+	url = https://github.com/patriciogonzalezvivo/vera.git


### PR DESCRIPTION
* Currently, one cannot retrieve the `vera` submodule as the url is to the private ssh url. 
* This PR adjusts the url to the "public" https-version.