### PR TITLE
Fix: if statement has empty body

### DIFF
--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -1438,7 +1438,7 @@ void Sandbox::renderPrep() {
 
     // BUFFERS
     // -----------------------------------------------
-    if (m_update_buffers);
+    if (m_update_buffers)
         _updateBuffers();
 
     if (uniforms.buffers.size() > 0 || 


### PR DESCRIPTION
Looks like a bug, found through compiler warning:
```
/Users/mlg/code/glslViewer/src/sandbox.cpp:1441:26: warning: if statement has empty body [-Wempty-body]
    if (m_update_buffers);
```