### PR TITLE
fix for building on windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,9 @@
 	# url = git@github.com:patriciogonzalezvivo/vera.git
 [submodule "deps/pybind11"]
 	path = deps/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
+	# url = git@github.com:pybind/pybind11.git
 [submodule "deps/lygia"]
 	path = deps/lygia
-	url = git@github.com:patriciogonzalezvivo/lygia.git
+	url = http://github.com/patriciogonzalezvivo/lygia.git
+	#url = git@github.com:patriciogonzalezvivo/lygia.git


### PR DESCRIPTION
"Failed to clone 'deps/lygia'. Retry scheduled
Cloning into '...deps/pybind11'...
Host key verification failed.
fatal: Could not read from remote repository."

Changing to https instead of ssh allow finishing
git submodule update
succesfully.