### PR TITLE
fixed http to https for lygia submodule dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	# url = git@github.com:pybind/pybind11.git
 [submodule "deps/lygia"]
 	path = deps/lygia
-	url = http://github.com/patriciogonzalezvivo/lygia.git
+	url = https://github.com/patriciogonzalezvivo/lygia.git
 	#url = git@github.com:patriciogonzalezvivo/lygia.git


### PR DESCRIPTION
When initializing the submodules, a brief warning appears that the lygia dependency was redirected to https. This fixes the issue and fetches lygia directly for the https URL.