### PR TITLE
Desktop file icon fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ else()
             # Install glslViewer Icon
             install(FILES "${PROJECT_SOURCE_DIR}/assets/glslViewer.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps)
             install(FILES "${PROJECT_SOURCE_DIR}/assets/glslViewer.desktop" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
-            install(CODE "execute_process(COMMAND sh -c \"echo Icon=${CMAKE_INSTALL_FULL_DATAROOTDIR}/pixmaps/glslViewer.png >> ${CMAKE_INSTALL_FULL_DATAROOTDIR}/applications/glslViewer.desktop\")")
+            install(CODE "execute_process(COMMAND sh -c \"echo Icon=${CMAKE_INSTALL_FULL_DATAROOTDIR}/pixmaps/glslViewer.png >> ${CMAKE_INSTALL_DATAROOTDIR}/applications/glslViewer.desktop\")")
             
             # Install supported MIME file types by GlslViewer
             install(FILES "${PROJECT_SOURCE_DIR}/assets/glslViewer-types.xml" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/mime/packages)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,6 @@ else()
             # Install glslViewer Icon
             install(FILES "${PROJECT_SOURCE_DIR}/assets/glslViewer.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps)
             install(FILES "${PROJECT_SOURCE_DIR}/assets/glslViewer.desktop" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
-            install(CODE "execute_process(COMMAND sh -c \"echo Icon=${CMAKE_INSTALL_FULL_DATAROOTDIR}/pixmaps/glslViewer.png >> ${CMAKE_INSTALL_DATAROOTDIR}/applications/glslViewer.desktop\")")
             
             # Install supported MIME file types by GlslViewer
             install(FILES "${PROJECT_SOURCE_DIR}/assets/glslViewer-types.xml" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/mime/packages)

--- a/assets/glslViewer.desktop
+++ b/assets/glslViewer.desktop
@@ -10,3 +10,4 @@ Exec=glslViewer %f --msaa -e dynamic_shadows,on
 Terminal=true
 MimeType=model/lst;model/ply;model/obj;model/gltf-binary;model/gltf+json
 Categories=Graphics;3DGraphics;Viewer;
+Icon=glslViewer


### PR DESCRIPTION
First commit fixes the .desktop file path in `CMakeLists.txt` when writing `Icon=...` in the desktop file, and finally just hardcode the Icon key in the .desktop file with the second commit, as discussed in https://github.com/patriciogonzalezvivo/glslViewer/issues/344.

Unfortunately I was unable to test building these, as I got unrelated error from vera, but the changes are very simple and I can't think of a reason how they could cause problems.